### PR TITLE
docs: add note about '--' behavior to `shorebird release` docs

### DIFF
--- a/docs/code_push/release.md
+++ b/docs/code_push/release.md
@@ -50,6 +50,6 @@ https://support.google.com/googleplay/android-developer/answer/9859152?hl=en
 `shorebird release` wraps `flutter build` and can take any argument
 `flutter build` can. To pass arguments to the underlying `flutter build` you
 need to put `flutter build` arguments after a `--` separator. For example:
-`shorebird build -- --dart-define="foo=bar"` will define the `"foo"` environment
+`shorebird release -- --dart-define="foo=bar"` will define the `"foo"` environment
 variable inside Dart as you might have done with `flutter build` directly.
 :::

--- a/docs/code_push/release.md
+++ b/docs/code_push/release.md
@@ -45,3 +45,11 @@ Your next step is to upload the app bundle to the Play Store.
 See the following link for more information:
 https://support.google.com/googleplay/android-developer/answer/9859152?hl=en
 ```
+
+:::info
+`shorebird release` wraps `flutter build` and can take any argument
+`flutter build` can. To pass arguments to the underlying `flutter build` you
+need to put `flutter build` arguments after a `--` separator. For example:
+`shorebird build -- --dart-define="foo=bar"` will define the `"foo"` environment
+variable inside Dart as you might have done with `flutter build` directly.
+:::


### PR DESCRIPTION
Adds the same note about the `--` behavior to `shorebird release` docs that exists in `shorebird build` and `shorebird run`.

Fixes https://github.com/shorebirdtech/shorebird/issues/421