### PR TITLE
chore: use our discord vanity url everywhere

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,7 +5,7 @@ description: Frequently asked questions.
 ---
 
 If you have questions not answered here, please ask! Both filing an issue
-or asking on [Discord](https://discord.gg/9hKJcWGcaB)) work.
+or asking on [Discord](https://discord.gg/shorebird)) work.
 
 ### What is "code push"?
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,7 +89,7 @@ const config = {
               },
               {
                 label: 'Discord',
-                href: 'https://discord.gg/9hKJcWGcaB',
+                href: 'https://discord.gg/shorebird',
               },
               {
                 label: 'Twitter',


### PR DESCRIPTION
Use our vanity url everywhere instead of a direct invite link.