### PR TITLE
Update status page to remove collaborators from 'what does't work yet'

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -10,8 +10,7 @@ Shorebird is currently available to the general public and many customers are us
 production.
 
 We're working closely with our customers to ensure we're building things
-they want. We _want_ your feedback. We _want_ you to
-break things. We _want_ you to tell us what you want to see next.
+they want. We _want_ your feedback. We _want_ you to tell us what you want to see next.
 
 Filing [issues](https://github.com/shorebirdtech/shorebird/issues) is a good way
 to provide feedback. Feedback via Discord is also welcome.
@@ -39,7 +38,6 @@ No support for:
 
 - iOS [coming soon](https://www.youtube.com/watch?v=7KDgFvdogsE) [issue](https://github.com/shorebirdtech/shorebird/issues/381)
 - Asset changes (images, icons, etc.) [issue](https://github.com/shorebirdtech/shorebird/issues/318)
-- Teams / Organizations sharing apps [issue](https://github.com/shorebirdtech/shorebird/issues/216)
 - Older Flutter versions or `beta` and `master` channels (only latest `stable` is supported): [issue](https://github.com/shorebirdtech/shorebird/issues/472)
 - Rollbacks ([issue](https://github.com/shorebirdtech/shorebird/issues/126))
 - Staged rollout of patches (channels or percentage based) [issue](https://github.com/shorebirdtech/shorebird/issues/110)

--- a/docs/status.md
+++ b/docs/status.md
@@ -26,8 +26,9 @@ You can build and deploy new (release) versions of your app to all Android
 users via `shorebird` command line. iOS support is
 [coming soon](https://www.youtube.com/watch?v=7KDgFvdogsE).
 
-All users will update to the new version on next launch in the background
-(no control over this behavior yet).
+All users will update to the new version on next launch in the background.
+Your app can check for updates and download them using the
+[shorebird_code_push](https://pub.dev/packages/shorebird_code_push) package.
 
 We also have an extensive command line interface for managing your Shorebird
 account and apps and CI/CD integration via GitHub Actions.


### PR DESCRIPTION
Also no longer implores customers to break things.