### PR TITLE
Update CodeMagic install instructions to support linux

### DIFF
--- a/docs/ci/codemagic.mdx
+++ b/docs/ci/codemagic.mdx
@@ -110,9 +110,22 @@ scripts:
     script: |
       # Install Shorebird
       curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash
+      
+      OS=$(uname)
 
-      # Add Shorebird to PATH
-      echo PATH="/Users/builder/.shorebird/bin:$PATH" >> $CM_ENV
+      if [ "$OS" == "Darwin" ]; then
+        echo PATH="/Users/builder/.shorebird/bin:$PATH" >> $CM_ENV
+        export PATH="/Users/builder/.shorebird/bin:$PATH"
+      elif [ "$OS" == "Linux" ]; then
+        echo PATH="/home/builder/.shorebird/bin:$PATH" >> $CM_ENV
+        export PATH="/home/builder/.shorebird/bin:$PATH"
+      else
+        echo "Unsupported OS"
+        exit 1
+      fi
+
+      # Test
+      echo "Sucessfully installed Shorebird version $(shorebird --version)"
 ```
 
 3. Execute Shorebird commands in your workflow.


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Using a linux_x2 build machine, the 'Shorebuild build' phase of the CodeMagic yaml file was failing to find the `shorebird` command on the path. I checked the output of the install script and noticed that the suggested path was different from the documentation.

Switched to mac_mini_m1 and it worked fine.

Updated the script to check OS and set path accordingly. Added the # Test at the bottom to catch errors in the path early rather than waiting until the build phase for it to fail.

This script modification has been tested on:
- mac_mini_m1
- linux_x2
