### PR TITLE
Add notes about CONTINUOUS_INTEGRATION env variable

### DIFF
--- a/docs/ci/codemagic.mdx
+++ b/docs/ci/codemagic.mdx
@@ -89,9 +89,7 @@ In the `codemagic.yaml` file, specify the `SHOREBIRD_TOKEN` under `environment`.
   <TabItem value="maclinux" label="Mac/Linux" default>
 
 1. Add the group "shorebird" to your environment groups. If you're using a
-   different group name, use that instead. Also add the `CONTINUOUS_INTEGRATION`
-   variable to skip confirmation prompts.
-
+   different group name, use that instead.
 ```yaml
 workflows:
   example:
@@ -100,9 +98,6 @@ workflows:
       groups:
         # Exports the SHOREBIRD_TOKEN environment variable
         - shorebird
-      vars:
-        # Skip confirmation prompts
-        CONTINUOUS_INTEGRATION: 'true'
 ```
 
 2. Add a script to your workflow to set up Shorebird. This script will install
@@ -139,8 +134,6 @@ workflows:
       groups:
         - shorebird
       flutter: stable
-      vars:
-        CONTINUOUS_INTEGRATION: 'true'
     scripts:
       - name: 🐦 Setup Shorebird
         script: |
@@ -161,8 +154,7 @@ You can find a working example in this repository:
 
 1. Add the group containing `SHOREBIRD_TOKEN` to your environment groups (in our
    case, the "shorebird" group we created above). Also add a variable named `shorebird`
-   with the path to the Shorebird executable and a variable named
-   `CONTINUOUS_INTEGRATION` with a value of `true` to skip confirmation prompts.
+   with the path to the Shorebird executable.
 
 ```yaml
 workflows:
@@ -177,7 +169,6 @@ workflows:
         # Workaround for
         # https://github.com/orgs/codemagic-ci-cd/discussions/1921#discussioncomment-6582318
         shorebird: "C:\\Users\\builder\\.shorebird\\bin\\shorebird.ps1"
-        CONTINUOUS_INTEGRATION: 'true'
 ```
 
 2. Add a script to your workflow to set up Shorebird. This script will install
@@ -251,7 +242,6 @@ workflows:
     environment:
       vars:
         TYPE: 'patch' # Can be 'patch' or 'release'
-        CONTINUOUS_INTEGRATION: 'true'
       groups:
         # Exports the SHOREBIRD_TOKEN environment variable
         - shorebird

--- a/docs/ci/codemagic.mdx
+++ b/docs/ci/codemagic.mdx
@@ -89,7 +89,8 @@ In the `codemagic.yaml` file, specify the `SHOREBIRD_TOKEN` under `environment`.
   <TabItem value="maclinux" label="Mac/Linux" default>
 
 1. Add the group "shorebird" to your environment groups. If you're using a
-   different group name, use that instead.
+   different group name, use that instead. Also add the `CONTINUOUS_INTEGRATION`
+   variable to skip confirmation prompts.
 
 ```yaml
 workflows:
@@ -99,6 +100,9 @@ workflows:
       groups:
         # Exports the SHOREBIRD_TOKEN environment variable
         - shorebird
+      vars:
+        # Skip confirmation prompts
+        CONTINUOUS_INTEGRATION: 'true'
 ```
 
 2. Add a script to your workflow to set up Shorebird. This script will install
@@ -120,7 +124,7 @@ scripts:
 ```yaml
 scripts:
   - name: 🚀 Shorebird Patch
-    script: shorebird patch android --force
+    script: shorebird patch android
 ```
 
 ### Full Example
@@ -135,6 +139,8 @@ workflows:
       groups:
         - shorebird
       flutter: stable
+      vars:
+        CONTINUOUS_INTEGRATION: 'true'
     scripts:
       - name: 🐦 Setup Shorebird
         script: |
@@ -144,7 +150,7 @@ workflows:
           # Add Shorebird to PATH
           echo PATH="$HOME/.shorebird/bin:$PATH" >> $CM_ENV
       - name: 🚀 Shorebird Patch
-        script: shorebird patch android --force
+        script: shorebird patch android
 ```
 
 You can find a working example in this repository:
@@ -155,7 +161,8 @@ You can find a working example in this repository:
 
 1. Add the group containing `SHOREBIRD_TOKEN` to your environment groups (in our
    case, the "shorebird" group we created above). Also add a variable named `shorebird`
-   with the path to the Shorebird executable.
+   with the path to the Shorebird executable and a variable named
+   `CONTINUOUS_INTEGRATION` with a value of `true` to skip confirmation prompts.
 
 ```yaml
 workflows:
@@ -170,6 +177,7 @@ workflows:
         # Workaround for
         # https://github.com/orgs/codemagic-ci-cd/discussions/1921#discussioncomment-6582318
         shorebird: "C:\\Users\\builder\\.shorebird\\bin\\shorebird.ps1"
+        CONTINUOUS_INTEGRATION: 'true'
 ```
 
 2. Add a script to your workflow to set up Shorebird. This script will install
@@ -189,7 +197,7 @@ scripts:
 scripts:
   - name: 🚀 Shorebird Release
     script: |
-      & $env:shorebird release android --force
+      & $env:shorebird release android
 ```
 
 ### Full Example
@@ -217,7 +225,7 @@ workflows:
           iwr -UseBasicParsing 'https://raw.githubusercontent.com/shorebirdtech/install/main/install.ps1'|iex
       - name: 🚀 Shorebird Release
         script: |
-          & $env:shorebird release android --force
+          & $env:shorebird release android
 ```
 
 You can find a working example in this repository:
@@ -243,6 +251,7 @@ workflows:
     environment:
       vars:
         TYPE: 'patch' # Can be 'patch' or 'release'
+        CONTINUOUS_INTEGRATION: 'true'
       groups:
         # Exports the SHOREBIRD_TOKEN environment variable
         - shorebird
@@ -268,10 +277,10 @@ workflows:
           # Check type and run corresponding command
           if [ "$TYPE" == "patch" ]; then
             echo "🩹 Running patch command"
-            shorebird patch android --force
+            shorebird patch android
           elif [ "$TYPE" == "release" ]; then
             echo "🚀 Running release command"
-            shorebird release android --force
+            shorebird release android
           fi
 ```
 

--- a/docs/ci/codemagic.mdx
+++ b/docs/ci/codemagic.mdx
@@ -90,6 +90,7 @@ In the `codemagic.yaml` file, specify the `SHOREBIRD_TOKEN` under `environment`.
 
 1. Add the group "shorebird" to your environment groups. If you're using a
    different group name, use that instead.
+
 ```yaml
 workflows:
   example:

--- a/docs/ci/github.md
+++ b/docs/ci/github.md
@@ -100,6 +100,9 @@ secret: <THE GENERATED SHOREBIRD_TOKEN>
 
 Now we can use the `SHOREBIRD_TOKEN` in our GitHub workflow to perform authenticated functions such as creating patches 🎉
 
+We also set the `CONTINUOUS_INTEGRATION` environment variable to `true` to
+prevent Shorebird from prompting for confirmation.
+
 ```yaml
 name: Shorebird Patch
 
@@ -109,6 +112,9 @@ on:
       release_version:
         description: The release version to patch
         required: true
+
+env:
+  CONTINUOUS_INTEGRATION: true
 
 jobs:
   patch:
@@ -126,7 +132,7 @@ jobs:
         uses: shorebirdtech/setup-shorebird@v0
 
       - name: 🚀 Shorebird Patch
-        run: shorebird patch android --release-version ${{ inputs.release_version }} --force
+        run: shorebird patch android --release-version ${{ inputs.release_version }}
         env:
           SHOREBIRD_TOKEN: ${{ secrets.SHOREBIRD_TOKEN }}
 ```

--- a/docs/ci/github.md
+++ b/docs/ci/github.md
@@ -100,9 +100,6 @@ secret: <THE GENERATED SHOREBIRD_TOKEN>
 
 Now we can use the `SHOREBIRD_TOKEN` in our GitHub workflow to perform authenticated functions such as creating patches 🎉
 
-We also set the `CONTINUOUS_INTEGRATION` environment variable to `true` to
-prevent Shorebird from prompting for confirmation.
-
 ```yaml
 name: Shorebird Patch
 
@@ -112,9 +109,6 @@ on:
       release_version:
         description: The release version to patch
         required: true
-
-env:
-  CONTINUOUS_INTEGRATION: true
 
 jobs:
   patch:


### PR DESCRIPTION
## Status

**READY**

## Description

Removes the use of `--force`

As per [CodeMagic](https://docs.codemagic.io/yaml-basic-configuration/environment-variables/) and [GitHub](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) docs, CodeMagic will always set the `CI` and `CONTINUOUS_INTEGRATION` variables to true and GitHub will always set `GITHUB_ACTIONS` to true, so no additional setup is required once https://github.com/shorebirdtech/shorebird/pull/1099 lands.

Part of https://github.com/shorebirdtech/shorebird/issues/1097
