### PR TITLE
Replace references to releases list command with console links

### DIFF
--- a/docs/code_push/release.mdx
+++ b/docs/code_push/release.mdx
@@ -145,27 +145,7 @@ shorebird release ios-alpha --force
 ### List Releases
 
 You can view all of your releases for your current app (as defined by
-your shorebird.yaml) using `shorebird releases list`.
-
-Example output:
-
-```
-$ shorebird releases list
-🚀 Releases (675a3bf6-fdf9-4520-a5f5-f73493ef9034)
-┌───────────┬──────┐
-│ Version   │ Name │
-├───────────┼──────┤
-│ 1.0.2+1   │ --   │
-├───────────┼──────┤
-│ 1.0.3+1   │ --   │
-└───────────┴──────┘
-```
-
-If your application supports flavors, you can specify the flavor using the `--flavor` option:
-
-```
-shorebird releases list --flavor development
-```
+your shorebird.yaml) on the [Shorebird console](https://console.shorebird.dev/).
 
 ### Delete Releases
 

--- a/docs/guides/release/android.md
+++ b/docs/guides/release/android.md
@@ -19,28 +19,9 @@ This guide assumes that you have an existing Shorebird app. If you don't have on
 
 ### Determine next release version
 
-Start by running `shorebird releases list` to see the current set of releases:
-
-```
-bryanoltman@boltman ~/Shorebird/time_shift (main)
-⑆ shorebird releases list
-🚀 Releases (51751336-6a7c-4972-b4ec-8fc1591fb2b3)
-┌─────────┬──────┐
-│ Version │ Name │
-├─────────┼──────┤
-│ 1.0.1   │ --   │
-├─────────┼──────┤
-│ 1.0.2+1 │ --   │
-├─────────┼──────┤
-│ 1.0.2+5 │ --   │
-└─────────┴──────┘
-```
-
-This shows that the most recent release is `1.0.2+5`. This corresponds with what we see in the Play Store console:
-
-![ReleaseVersion](https://github.com/shorebirdtech/docs/assets/581764/e6b6c276-49de-4142-8f32-dbf5e41379fa)
-
-Next, we'll create a new release for version `1.0.3+6`.
+Navigate to your app on the [Shorebird console](https://console.shorebird.dev/)
+to see the current set of releases. For our app, we see that the latest release
+version is `1.0.2+5`, so the version of our next release will be `1.0.3+6`.
 
 ### Make code changes
 

--- a/docs/guides/release/ios.md
+++ b/docs/guides/release/ios.md
@@ -33,19 +33,9 @@ To build an iOS app for distribution, we need to specify a development team in X
 
 ### Determine the release version
 
-Run `shorebird releases list` to see the current set of releases:
-
-```
-⑆ shorebird releases list
-🚀 Releases (f2184ee6-9a85-498c-bfeb-114d638c462e)
-┌─────────┬──────┐
-│ Version │ Name │
-├─────────┼──────┤
-│ 1.0.3+1 │ --   │
-└─────────┴──────┘
-```
-
-This shows that the most recent release is `1.0.3+1`. Our next version will be `1.0.4+1`.
+Navigate to your app on the [Shorebird console](https://console.shorebird.dev/)
+to see the current set of releases. For our app, we see that the latest release
+version is `1.0.3.+1`, so the version of our next release will be `1.0.4+1`.
 
 ### Create a release in App Store Connect
 


### PR DESCRIPTION
## Status

**READY**

## Description

The `shorebird releases list` command has been deprecated in favor of console.shorebird.dev. This change updates the docs to reflect that.
