### PR TITLE
doc: clarify that we do not back-port features

### DIFF
--- a/docs/flutter-version.md
+++ b/docs/flutter-version.md
@@ -109,7 +109,7 @@ to the following table for the status of each feature across Flutter versions:
 | 3.10.0  |    ✓    |  ✗  |              ✗              |
 
 :::info
-Over time we would like to bring Shorebird support to more Flutter versions. If
+We would like Shorebird to support to as many Flutter versions as possible. If
 there are older versions of Flutter which you need Shorebird to support, please
 [let us know](https://github.com/shorebirdtech/shorebird/issues/1100).
 :::

--- a/docs/flutter-version.md
+++ b/docs/flutter-version.md
@@ -15,10 +15,7 @@ Shorebird currently focuses our efforts on support for the latest stable version
 of Flutter. When we make changes to Shorebird we do not currently backport those
 changes to previous release of Flutter.
 
-We do make our previous releases of Flutter available back to 3.10.0. Publishing
-a new app with an older Shorebird Flutter is supported, but it may not contain
-all of the most recent Shorebird features. We recommend using the latest stable
-version of Flutter whenever possible.
+While we support creating a release with older versions of Flutter (back to 3.10.0), a release created with one of these versions may not contain all of the most recent Shorebird features. Because of this, we recommend using the latest stable version of Flutter whenever possible.
 
 ## List Flutter Versions
 

--- a/docs/flutter-version.md
+++ b/docs/flutter-version.md
@@ -9,9 +9,21 @@ description: How to manage your Shorebird Flutter version
 When Shorebird CLI is installed, it pulls down the latest stable version of Shorebird's Flutter.
 In this section, we'll take a look at how to list and change the Flutter version used by Shorebird CLI.
 
+## Supported Flutter Versions
+
+Shorebird currently focuses our efforts on support for the latest stable version
+of Flutter. When we make changes to Shorebird we do not currently backport those
+changes to previous release of Flutter.
+
+We do make our previous releases of Flutter available back to 3.10.0. Publishing
+a new app with an older Shorebird Flutter is supported, but it may not contain
+all of the most recent Shorebird features. We recommend using the latest stable
+version of Flutter whenever possible.
+
 ## List Flutter Versions
 
-To list all supported Flutter versions, use the `shorebird flutter versions list` command:
+To list all Flutter versions Shorebird has published, use the
+`shorebird flutter versions list` command:
 
 ```
 $ shorebird flutter versions list
@@ -43,7 +55,8 @@ Another way to see the current Flutter version is by running `shorebird --versio
 
 ## Switch Flutter Versions
 
-To switch to a different Flutter version, use the `shorebird flutter versions use <version>` command:
+To switch to a different Flutter version, use the
+`shorebird flutter versions use <version>` command:
 
 ```
 $ shorebird flutter versions use 3.10.3
@@ -71,20 +84,35 @@ $ shorebird flutter versions list
   3.10.0
 ```
 
-This will install and cache the corresponding revision of Flutter on your machine and switch to using that version as the default for all subsequent `shorebird` commands.
+This will install and cache the corresponding revision of Flutter on your
+machine and switch to using that version as the default for all subsequent
+`shorebird` commands.
 
-## Support Matrix
+## Supported Feature Matrix
 
-At this time, not all functionality is supported for each Flutter version. Refer to the following table for the status of each feature across Flutter versions:
+At this time, not all functionality is supported for each Flutter version. Refer
+to the following table for the status of each feature across Flutter versions:
 
-|                             | 3.10.0 | 3.10.1 | 3.10.2 | 3.10.3 | 3.10.4 | 3.10.5 | 3.10.6 | 3.10.7 | 3.13.0 | 3.13.1 | 3.13.2 | 3.13.3 | 3.13.4 | 3.13.5 | 3.13.6 |
-| --------------------------- | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: |
-| Android                     |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |
-| iOS                         |   ✗    |   ✗    |   ✗    |   ✗    |   ✗    |   ✗    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |
-| package:shorebird_code_push |   ✗    |   ✗    |   ✗    |   ✗    |   ✗    |   ✗    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |
-| Flavors                     |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |
-| Add to App                  |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |   ✓    |
+| Version | Android | iOS | package:shorebird_code_push |
+| ------- | :-----: | :-: | :-------------------------: |
+| 3.13.6  |    ✓    |  ✓  |              ✓              |
+| 3.13.5  |    ✓    |  ✓  |              ✓              |
+| 3.13.4  |    ✓    |  ✓  |              ✓              |
+| 3.13.3  |    ✓    |  ✓  |              ✓              |
+| 3.13.2  |    ✓    |  ✓  |              ✓              |
+| 3.13.1  |    ✓    |  ✓  |              ✓              |
+| 3.13.0  |    ✓    |  ✓  |              ✓              |
+| 3.10.7  |    ✓    |  ✓  |              ✓              |
+| 3.10.6  |    ✓    |  ✓  |              ✓              |
+| 3.10.5  |    ✓    |  ✗  |              ✗              |
+| 3.10.4  |    ✓    |  ✗  |              ✗              |
+| 3.10.3  |    ✓    |  ✗  |              ✗              |
+| 3.10.2  |    ✓    |  ✗  |              ✗              |
+| 3.10.1  |    ✓    |  ✗  |              ✗              |
+| 3.10.0  |    ✓    |  ✗  |              ✗              |
 
 :::info
-We are working bringing all functionality to all currently supported Flutter versions. If there are older versions of Flutter which you need Shorebird to support, please [let us know](https://github.com/shorebirdtech/shorebird/issues/new/choose).
+Over time we would like to bring Shorebird support to more Flutter versions. If
+there are older versions of Flutter which you need Shorebird to support, please
+[let us know](https://github.com/shorebirdtech/shorebird/issues/1100).
 :::


### PR DESCRIPTION
Also inverted the feature matrix to make it easier to edit.

Also linked to the "older versions" bug rather than directing customers to file a new bug.