### PR TITLE
doc: explain how to pass args to flutter build from patch

### DIFF
--- a/docs/code_push/patch.mdx
+++ b/docs/code_push/patch.mdx
@@ -72,3 +72,11 @@ If your application supports flavors or multiple release targets, you can specif
 ```
 shorebird patch --target ./lib/main_development.dart --flavor development
 ```
+
+:::info
+`shorebird patch` wraps `flutter build` and can take any argument
+`flutter build` can. To pass arguments to the underlying `flutter build` you
+need to put `flutter build` arguments after a `--` separator. For example:
+`shorebird patch android -- --dart-define="foo=bar"` will define the `"foo"` environment
+variable inside Dart as you might have done with `flutter build` directly.
+:::


### PR DESCRIPTION
We had a customer who thought they only worked on `release` so adding a note to patch too.