### PR TITLE
Add note about how preview can be used

### DIFF
--- a/docs/code_push/preview.md
+++ b/docs/code_push/preview.md
@@ -14,3 +14,7 @@ shorebird preview
 ```
 
 This will download the release artifacts for the selected app release version, install the app on the selected device, and start the application.
+
+:::tip
+`shorebird preview` can be used on any computer that is configured for Flutter development, not just the computer that was used to create the release. This is useful for verifying releases that were created on a CI/CD server.
+:::


### PR DESCRIPTION
## Status

**READY**

## Description

Adds tip callout to `code_push/preview` informing the user what is required to use `shorebird preview` and suggesting previewing CI/CD-created releases.
