### PR TITLE
Update teams doc to reference shorebird console

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -69,21 +69,17 @@ Global options:
 -v, --[no-]verbose    Noisy logging, including all shell commands executed.
 
 Available commands:
-  account         Manage your Shorebird account.
-  apps            Manage your Shorebird apps.
-  cache           Manage the Shorebird cache.
-  collaborators   Manage collaborators for a Shorebird app
-  doctor          Show information about the installed tooling.
-  flutter         Manage your Shorebird Flutter installation.
-  init            Initialize Shorebird.
-  login           Login as a new Shorebird user.
-  login:ci        Login as a CI user.
-  logout          Logout of the current Shorebird user
-  patch           Manage patches for a specific release in Shorebird.
-  preview         Preview a specific release on a device.
-  release         Manage your Shorebird app releases.
-  releases        Manage your releases.
-  upgrade         Upgrade your copy of Shorebird.
+  cache      Manage the Shorebird cache.
+  doctor     Show information about the installed tooling.
+  flutter    Manage your Shorebird Flutter installation.
+  init       Initialize Shorebird.
+  login      Login as a new Shorebird user.
+  login:ci   Login as a CI user.
+  logout     Logout of the current Shorebird user
+  patch      Manage patches for a specific release in Shorebird.
+  preview    Preview a specific release on a device.
+  release    Manage your Shorebird app releases.
+  upgrade    Upgrade your copy of Shorebird.
 
 Run "shorebird help <command>" for more information about a command.
 ```
@@ -98,12 +94,13 @@ Example output:
 
 ```
 $ shorebird doctor
-Shorebird 0.12.1 • git@github.com:shorebirdtech/shorebird.git
-Flutter 3.10.6 • revision 0e2d280277cf9f60f7ba802a59f9fd187ffdd050
-Engine • revision bf07ad7b0b777cb9aff15e59bf928504857f4ada
+Shorebird 0.18.4 • git@github.com:shorebirdtech/shorebird.git
+Flutter 3.13.9 • revision 39df2792f537b1fc62a9c668a6990f585bd91456
+Engine • revision e81fa131e59506d9f6af2a0cee7de749131f1bf0
 
-✓ Shorebird is up-to-date (0.8s)
-✓ Flutter install is correct (3.2s)
+✓ Shorebird is up-to-date (0.5s)
+✓ Flutter install is correct (0.3s)
+✓ Has access to storage.googleapis.com (0.2s)
 
 No issues detected!
 ```

--- a/docs/teams.md
+++ b/docs/teams.md
@@ -47,37 +47,19 @@ if you need to add/remove Admins from an app.
 
 Owner can be changed by contacting us.
 
-## Adding a Collaborator
+## Managing Collaborators
 
-Currently collaborators must be added and removed using the Shorebird
-command line tool. We intend to add support for adding and removing
-collaborators via the Shorebird console in the future.
-<https://github.com/shorebirdtech/shorebird/issues/1221>
+Collaborators can be managed on the Shorebird console. To add a collaborator,
+from your app's page:
 
-To add a collaborator, run:
+1. Select the "Collaborators" tab.
+2. Click "Add people".
+3. Enter the email address of the person you would like to add as a collaborator.
+   1. Note that the email address must be associated with an existing Shorebird account.
+4. Click "Add Collaborator".
 
-```bash
-shorebird collaborators add --email <email>
-```
-
-`--app-id` is optional if you are in a directory with a Shorebird app it
-will infer the app ID from `shorebird.yaml`. Otherwise you can specify
-`--app-id <app-id>`.
-
-Collaborators must already have created a Shorebird account with the email
-address you are adding. They can do so by loading the Shorebird console
-and clicking "Continue with Google".
-
-We intend to add the ability to invite collaborators via email in the future.
-<https://github.com/shorebirdtech/shorebird/issues/1221>
-
-## Removing a Collaborator
-
-To remove a collaborator, run:
-
-```bash
-shorebird collaborators remove --email <email>
-```
+Existing collaborators can be removed by clicking the trash icon next to their
+email address.
 
 ## Sharing Multiple Apps
 


### PR DESCRIPTION
This also updates what we show as the output of the `shorebird` command, as that has changed significantly since the docs were last updated.