### PR TITLE
doc: add a doc on getting crash reporting symbols

### DIFF
--- a/docs/guides/crash-reporting.md
+++ b/docs/guides/crash-reporting.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 3
+slug: crash-reporting
+title: Crash Reporting
+sidebar_label: 🚑 Crash Reporting
+description: Use Shorebird with crash reporting tools
+---
+
+# Integrating with Crash Reporting Tools
+
+Shorebird uses a fork of Flutter to build your app.  This means we've built
+our own copy of Flutter's engine which means that the symbols included in
+the Flutter.framework or libflutter.so are slightly different from the
+upstream Flutter engine.
+
+If you would like to see C++ symbols from our fork of Flutter's engine in your crash reports, you will need to
+upload the symbols to your crash reporting tool.
+
+Google provides instructions for how to integrate various crash reporting
+tools into your Flutter app:
+
+https://docs.flutter.dev/cookbook/maintenance/error-reporting
+
+# Getting Symbols for Shorebird's Flutter Fork
+
+For a given Flutter version you will need the Flutter engine hash
+to download the symbols.  This hash is displayed in `shorebird doctor`
+output:
+```
+% shorebird doctor
+Shorebird 0.24.1 • git@github.com:shorebirdtech/shorebird.git
+Flutter 3.16.7 • revision ba46e8490348d6989283c9cff2b95727f0969d04
+Engine • revision 974eae888fdedd890b74c84e55a454bb7fcbd7de
+```
+
+In this case, we're using `974eae888fdedd890b74c84e55a454bb7fcbd7de` as the
+engine hash.
+
+## Symbols for iOS
+
+Assuming engine hash `974eae888fdedd890b74c84e55a454bb7fcbd7de`, the iOS symbols can be downloaded from the following URL:
+
+https://download.shorebird.dev/flutter_infra_release/flutter/974eae888fdedd890b74c84e55a454bb7fcbd7de/ios-release/Flutter.dSYM.zip
+
+## Symbols for Android
+
+Assuming engine hash `974eae888fdedd890b74c84e55a454bb7fcbd7de`, the Android symbols can be downloaded from the following URL:
+
+https://download.shorebird.dev/flutter_infra_release/flutter/974eae888fdedd890b74c84e55a454bb7fcbd7de/android-release/flutter-974eae888fdedd890b74c84e55a454bb7fcbd7de-symbols.zip


### PR DESCRIPTION
We may just want to expose these as urls in the console instead?