### PR TITLE
docs: fix typo in side-loading section

### DIFF
--- a/docs/code_push/release.mdx
+++ b/docs/code_push/release.mdx
@@ -174,7 +174,7 @@ shorebird releases delete --flavor development
 
 ## 📲 Side-loading and MDM
 
-A common question we get asked, is does Shorebird require publishing to the
+A common question we get asked is: Does Shorebird require publishing to the
 App Store or Play Store?
 
 No. Shorebird works fine with side-loading and mobile device management (MDM)


### PR DESCRIPTION
## Status

READY

## Description

Fixes a typo in the first line of the 'Side-loading and MDM' section's description
