### PR TITLE
Remove references of expo.dev

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -16,8 +16,7 @@ Shorebird currently works on Android and iOS (alpha) and will eventually work
 everywhere Flutter works.
 
 "Code Push" is a reference to the name of a deploy feature used by the React
-Native community from [Microsoft](https://appcenter.ms) and
-[Expo](https://expo.dev), neither of which support Flutter.
+Native community from [Microsoft](https://appcenter.ms), neither of which support Flutter.
 
 ## Patching
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,7 +87,7 @@ your account.
 
 Code push services are widely used in the industry (all of the large
 apps I'm aware of use them) and there are multiple other code push services
-publicly available (e.g. expo.dev & appcenter.ms). This is a well trodden path.
+publicly available (e.g. appcenter.ms). This is a well trodden path.
 
 Microsoft also publishes a guide on how their React Native "codepush" library
 complies with the app stores:


### PR DESCRIPTION
## Status

READY

## Description

I saw that there are references to expo.dev on Shorebird's docs and we'd like to remove them, to avoid any confusion about how our service works. We heard from a few people drawing comparisons and it took us awhile to explain how we're different.

Overall, we are trying to center our updates product around developer workflows, and provide the most value there. Also, I want to make sure users don't think that Expo's updates allow more than we offer, like that we only allow updating an app's JS bundle for critical bug fixes in production and we don't support accessing any native APIs or functionality.

Shorebird is a great project and an awesome tool for Flutter developers, I'm just trying to make sure users don't get confused along the way.