### PR TITLE
Reference shorebird preview in troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,24 +10,11 @@ Find help for issues with Shorebird.
 
 ## I created a patch, but it's not showing up in my app
 
-There are several reasons this might be happening. Common causes are:
+There are several reasons this might be happening. Start by running your release
+on a device or Android emulator using the `shorebird preview` command to see the
+log output.
 
-### The app you're running on your device/emulator was not built using one of the `shorebird release` commands.
-
-#### How to tell if this is the problem
-
-You can check this by checking your device logs for output from Shorebird. If
-you don't see anything like `Starting Shorebird update` or `Sending patch check
-request`, you are not running a Shorebird-built app.
-
-To check your device logs, run `adb logcat` in your terminal. You can filter the
-output to only show Flutter logs by running `adb logcat | grep flutter`.
-
-#### How to fix it
-
-Create a release using `shorebird release android --artifact=apk` commands and
-install the apk produced by that command on your device/emulator. When running
-this apk, you should see Shorebird logs in your device logs.
+Common causes of this problem are:
 
 ### The patch was created for a different release version than the one running on your device/emulator.
 
@@ -56,6 +43,24 @@ Sending patch check request: PatchCheckRequest {
 ```
 
 Only patches created for this release version will be compatible with your app.
+
+### The app you're running on your device/emulator was not built using one of the `shorebird release` commands.
+
+#### How to tell if this is the problem
+
+If you are running your app using `shorebird preview`, this is not the problem.
+
+If you have installed the app on your device/emulator a different way, check
+your device logs for output from Shorebird. If you don't see anything like
+`Starting Shorebird update` or `Sending patch check request`, you are not
+running a Shorebird-built app.
+
+To check your Android device logs, run `adb logcat` in your terminal. You can
+filter the output to only show Flutter logs by running `adb logcat | grep flutter`.
+
+#### How to fix it
+
+Use `shorebird preview`.
 
 ## I installed Shorebird, and now I can't run my app in VS Code
 


### PR DESCRIPTION
Adds reference to `shorebird preview` in the "I created a patch, but it's not showing up in my app" troubleshooting section, and recommends its use.