### PR TITLE
docs: tweek our linker status docs a little.

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -6,23 +6,26 @@ description: Status of the Shorebird project.
 
 ## Stable
 
-Shorebird is available on Android and iOS, with 1000s of apps shipping with
-Shorebird on the App Store and Play Store.
+Shorebird is available on Android and iOS, with ~1000 apps using Shorebird on
+the App Store and Play Store.
 
 ## Link Percentage (iOS)
 
-As part of complying with the the App Store guidelines, Shorebird uses a
-interpreter on iOS to run any changed Dart code in your patch. This interpreter
-is about 100x slower than running on the CPU. To make patches run fast,
-Shorebird has modified Dart to make it possible to _only_ run changed code on
-the interpreter and run any unchanged code on the CPU.
-
-Most of the time this works very well, and we're able to run 99% of code on the
-CPU. However there are still a few types of changes which can confuse our
-build system and cause more code to run on the interpreter than necessary.
+As part of [complying with the the App Store
+guidelines](faq#does-shorebird-comply-with-app-store-guidelines), Shorebird uses
+a interpreter on iOS to run any changed Dart code in your patch. This
+interpreter runs Dart about 100x slower than running on the CPU. To make patches
+run fast, Shorebird has modified Dart to make it possible to _only_ run changed
+code on the interpreter and run any unchanged code on the CPU. This
+determination is done at a per-function level.
 
 The program that decides which code runs on the CPU vs the interpreter is called
 the "linker" and we call this percentage the "link percentage".
+
+Most of the time this system works very well, and Shorebird is able to run 90%+
+of your Dart code on the CPU. However there are still a few types of changes
+which can confuse the "linker" into running more code on the interpreter than
+necessary.
 
 Any percentage below 50% might cause your app to run slower than normal, which
 is why you saw a warning and followed to this link.


### PR DESCRIPTION
We don't have great data on how many apps are in the stores with
Shorebird. We do know that we have about 1000 monthly active
developers, and several thousand 3mo active developers, so guessing
there are around 1000 apps in the stores.  It's certainly well into the
hundreds.

Also tweaked the wording and ordering a little.