### PR TITLE
docs: Missing subcommand on patch example output

### DIFF
--- a/docs/code_push/patch.mdx
+++ b/docs/code_push/patch.mdx
@@ -41,7 +41,7 @@ This will do several things:
 Example output:
 
 ```
-$ shorebird patch
+$ shorebird patch android
 ✓ Building patch (3.0s)
 ✓ Fetching apps (0.2s)
 ✓ Detecting release version (0.3s)


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Small docs improvement, in the example output for a the patch docs section, the subcommand (if it were an android or iOS patch) was missing.
