### PR TITLE
Update docs for accuracy and to reflect impending 1.0

### DIFF
--- a/docs/ci/github.md
+++ b/docs/ci/github.md
@@ -39,7 +39,7 @@ jobs:
     steps:
       # Use the setup-shorebird action to configure Shorebird
       - name: 🐦 Setup Shorebird
-        uses: shorebirdtech/setup-shorebird@v0
+        uses: shorebirdtech/setup-shorebird@v1
 
       # Now we're able to use Shorebird CLI in our workflow
       - name: 🚀 Use Shorebird
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🐦 Setup Shorebird
-        uses: shorebirdtech/setup-shorebird@v0
+        uses: shorebirdtech/setup-shorebird@v1
 
       - name: 🚀 Shorebird Release
         uses: shorebirdtech/shorebird-release@v0
@@ -173,7 +173,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🐦 Setup Shorebird
-        uses: shorebirdtech/setup-shorebird@v0
+        uses: shorebirdtech/setup-shorebird@v1
 
       # Note: all signing information (key.properties, etc.) must be set up on
       # this runner for `shorebird patch android` to work.

--- a/docs/code_push/patch.mdx
+++ b/docs/code_push/patch.mdx
@@ -69,8 +69,8 @@ Would you like to continue? (y/N) Yes
 
 If your application supports flavors or multiple release targets, you can specify the flavor and target using the `--flavor` and `--target` options:
 
-```
-shorebird patch --target ./lib/main_development.dart --flavor development
+```bash
+shorebird patch [android|ios] --target lib/main_development.dart --flavor development
 ```
 
 :::info

--- a/docs/code_push/release.mdx
+++ b/docs/code_push/release.mdx
@@ -13,31 +13,19 @@ import TabItem from '@theme/TabItem';
 
 In order to start pushing updates, you will need to create a release.
 
-<Tabs>
-
-<TabItem value="release-android" label="Android">
-
-`shorebird release android`
-
-</TabItem>
-
-<TabItem value="release-ios" label="iOS (beta)">
-
-`shorebird release ios`
-
-</TabItem>
-
-</Tabs>
-
 Creating a release builds and submits your app to Shorebird. Shorebird saves the
 compiled Dart code from your application in order to make updates smaller in
 size.
 
-Example output:
-
 <Tabs>
 
-<TabItem value="release-output-android" label="Android">
+<TabItem value="release-android" label="Android">
+
+Create an Android release by running the following command:
+
+`shorebird release android`
+
+Example output:
 
 ```
 $ shorebird release android
@@ -67,9 +55,37 @@ See the following link for more information:
 https://support.google.com/googleplay/android-developer/answer/9859152?hl=en
 ```
 
+If your application supports flavors or multiple release targets, you can specify the flavor and target using the `--flavor` and `--target` options:
+
+```bash
+shorebird release android --target ./lib/main_development.dart --flavor development
+```
+
+:::info
+`shorebird release` wraps `flutter build` and can take any argument
+`flutter build` can. To pass arguments to the underlying `flutter build` you
+need to put `flutter build` arguments after a `--` separator. For example:
+`shorebird release android -- --dart-define="foo=bar"` will define the `"foo"` environment
+variable inside Dart as you might have done with `flutter build` directly.
+:::
+
+By default, `shorebird release android` builds an AppBundle (`.aab`).
+If you would like to _also_ generate an Android Package Kit (`.apk`), use the
+following command:
+
+```bash
+shorebird release android --artifact apk
+```
+
 </TabItem>
 
-<TabItem value="release-output-ios" label="iOS (beta)">
+<TabItem value="release-output-ios" label="iOS">
+
+Create an iOS release by running the following command:
+
+`shorebird release ios`
+
+Example output:
 
 ```
 $ shorebird release ios
@@ -99,14 +115,10 @@ To upload to the App Store either:
        See "man altool" for details about how to authenticate with the App Store Connect API key.
 ```
 
-</TabItem>
-
-</Tabs>
-
 If your application supports flavors or multiple release targets, you can specify the flavor and target using the `--flavor` and `--target` options:
 
-```
-shorebird release --target ./lib/main_development.dart --flavor development
+```bash
+shorebird release ios --target ./lib/main_development.dart --flavor development
 ```
 
 :::info
@@ -117,28 +129,9 @@ need to put `flutter build` arguments after a `--` separator. For example:
 variable inside Dart as you might have done with `flutter build` directly.
 :::
 
-By default, `shorebird release android` builds an AppBundle (`.aab`).
-If you would like to _also_ generate an Android Package Kit (`.apk`), use the
-following command:
+</TabItem>
 
-```
-shorebird release android --artifact apk
-```
-
-:::tip
-If you would like to disable prompts and publish a release without confirmation, you can use the `--force` flag. This is especially useful when using `shorebird release android` in a CI environment.
-
-```
-shorebird release android --force
-```
-
-or
-
-```
-shorebird release ios --force
-```
-
-:::
+</Tabs>
 
 ## Manage Releases
 
@@ -155,22 +148,7 @@ and is **not reversible**.
 :::
 
 You can delete a release for your current app (as defined by your
-shorebird.yaml) using `shorebird releases delete`.
-
-Example output:
-
-```
-$ shorebird releases delete --version 1.0.3+1
-✓ Fetched releases. (54ms)
-Are you sure you want to delete release 1.0.3+1? (y/N) Yes
-✓ Deleted release 1.0.3+1. (0.3s)
-```
-
-If your application supports flavors, you can specify the flavor using the `--flavor` option:
-
-```
-shorebird releases delete --flavor development
-```
+shorebird.yaml) on the [Shorebird console](https://console.shorebird.dev/).
 
 ## 📲 Side-loading and MDM
 

--- a/docs/flutter-version.md
+++ b/docs/flutter-version.md
@@ -30,7 +30,9 @@ To list all Flutter versions Shorebird has published, use the
 
 ```
 $ shorebird flutter versions list
-✓ 3.19.3
+✓ 3.19.5
+  3.19.4
+  3.19.3
   3.19.2
   3.19.1
   3.19.0-0.4.pre

--- a/docs/guides/code_push_quickstart.mdx
+++ b/docs/guides/code_push_quickstart.mdx
@@ -11,7 +11,8 @@ import TabItem from '@theme/TabItem';
 
 This guide shows you the fastest way to install Shorebird and try code push.
 
-This document is a (slightly) condensed version of our [code push](../code-push/) docs, all on one page.
+This document is a (slightly) condensed version of our [code
+push](../code-push/) docs, all on one page.
 
 ## Sign up
 
@@ -19,9 +20,12 @@ Before you can create a Shorebird app, you will need to sign up for Shorebird.
 
 ### Create an account
 
-To create an account, head over to the [Shorebird Console](https://console.shorebird.dev) and authenticate with your Google account.
+To create an account, head over to the [Shorebird
+Console](https://console.shorebird.dev) and authenticate with your Google or
+Microsoft account.
 
-Once you have logged into the console, follow the instructions to install the Shorebird CLI on your machine.
+Once you have logged into the console, follow the instructions to install the
+Shorebird CLI on your machine.
 
 ## Create the app
 
@@ -55,9 +59,10 @@ contains your Shorebird `app_id`.
 This will also run `shorebird doctor` to ensure everything is set up correctly.
 
 :::info
-Shorebird expects to find the latest stable `flutter` installed on your machine.
-Shorebird can be configured to work with older versions of Flutter (back to 3.10.0).
-See (Flutter Version Management)[/flutter-version] for more info.
+Shorebird expects to find the latest stable `flutter` installed on your
+machine. Shorebird can be configured to work with older versions of Flutter
+(back to 3.10.0). See [Flutter Version Management](/flutter-version) for more
+info.
 :::
 
 ### Create a release
@@ -74,7 +79,7 @@ shorebird release android
 
 </TabItem>
 
-<TabItem value="ios" label="iOS (beta)">
+<TabItem value="ios" label="iOS">
 
 ```sh
 shorebird release ios
@@ -88,8 +93,8 @@ asked if you would like to continue.
 
 ### Preview the release
 
-To preview the release with Shorebird (that is, with [Shorebird's fork of the Flutter
-engine](/faq#how-does-shorebird-relate-to-flutter)), run:
+To preview the release with Shorebird (that is, with [Shorebird's fork of the
+Flutter engine](/faq#how-does-shorebird-relate-to-flutter)), run:
 
 ```sh
 shorebird preview
@@ -142,7 +147,7 @@ shorebird patch android
 
 </TabItem>
 
-<TabItem value="ios" label="iOS (beta)">
+<TabItem value="ios" label="iOS">
 
 ```sh
 shorebird patch ios
@@ -151,9 +156,6 @@ shorebird patch ios
 </TabItem>
 
 </Tabs>
-
-When prompted, use the suggested release version (`1.0.0+1`), and enter `y` when
-asked if you'd like to continue.
 
 ### See the patch in action
 

--- a/docs/guides/code_push_quickstart.mdx
+++ b/docs/guides/code_push_quickstart.mdx
@@ -21,8 +21,7 @@ Before you can create a Shorebird app, you will need to sign up for Shorebird.
 ### Create an account
 
 To create an account, head over to the [Shorebird
-Console](https://console.shorebird.dev) and authenticate with your Google or
-Microsoft account.
+Console](https://console.shorebird.dev) and authenticate with one of the available authentication methods.
 
 Once you have logged into the console, follow the instructions to install the
 Shorebird CLI on your machine.

--- a/docs/guides/flavors/android.md
+++ b/docs/guides/flavors/android.md
@@ -174,7 +174,7 @@ shorebird patch android --flavor internal
 We can validate the patch by visiting [Shorebird console](https://console.shorebird.dev/) then select the internal release or re-launching the internal release.
 
 :::note
-If you are testing locally, you don't need to re-run `shorebird preview` -- just re-launch the app from the device or emulator directly.
+If you are testing locally, you don't need to re-run `shorebird preview` – just re-launch the app from the device or emulator directly.
 :::
 
 The first time the app is re-launched, we should still see the purple theme and shorebird will detect and install the patch in the background. Kill and re-launch the app a second time to see the applied patch.

--- a/docs/guides/flavors/ios.md
+++ b/docs/guides/flavors/ios.md
@@ -88,7 +88,8 @@ In addition to previewing the releases locally, you should also [submit the gene
 
 - The `internal` variant should only be used for internal testing/validation.
 - The `stable` variant should be shipped to end users in production.
-  :::
+
+:::
 
 ## Creating a patch
 
@@ -128,10 +129,6 @@ class MyApp extends StatelessWidget {
   }
 }
 ```
-
-:::info
-Typically `shorebird patch` should be used to fix critical bugs.
-:::
 
 Now that we've applied the changes, let's patch the `internal` variant:
 

--- a/docs/guides/release/ios.md
+++ b/docs/guides/release/ios.md
@@ -59,8 +59,6 @@ Create a Shorebird release by running the `shorebird release ios` command:
 
 ```
 $ shorebird release ios
-[WARN] iOS support is beta. Some apps may run slower after patching.
-See https://docs.shorebird.dev/status for more information.
 ✓ Fetching apps (0.1s)
 ✓ Building release (56.2s)
 ✓ Getting release version (37ms)
@@ -155,8 +153,6 @@ To make this patch available to your users, run `shorebird patch ios`.
 
 ```
 $ shorebird patch ios
-[WARN] iOS support is beta. Some apps may run slower after patching.
-See https://docs.shorebird.dev/status for more information.
 ✓ Fetching apps (0.4s)
 ✓ Building release (61.5s)
 ✓ Detected release version 1.0.4+1 (44ms)


### PR DESCRIPTION
A bunch of updates to reflect latest versions of our github actions, removal of references to the deprecated `releases delete` command, and slight reorganization of the releases page in our guide.