### PR TITLE
feat: Don't repeat CI authentication docs

### DIFF
--- a/docs/ci/_ci_authentication.md
+++ b/docs/ci/_ci_authentication.md
@@ -1,0 +1,32 @@
+Most Shorebird functionality, like creating releases and patches, requires being authenticated. In order to authenticate with Shorebird in CI, you will need to generate a CI token.
+
+```sh
+shorebird login:ci
+```
+
+You will be prompted to go through a similar OAuth Flow as when using `shorebird login`, however, `shorebird login:ci` will not store any credentials on your device. Instead, a Shorebird token will be generated for you to use in CI.
+
+The output should look something like:
+
+```sh
+$ shorebird login:ci
+The Shorebird CLI needs your authorization to manage apps, releases, and patches on your behalf.
+
+In a browser, visit this URL to log in:
+
+https://accounts.google.com/o/oauth2/v2/auth...
+
+Waiting for your authorization...
+
+🎉 Success! Use the following token to login on a CI server:
+
+<SHOREBIRD_TOKEN>
+
+Example:
+
+export SHOREBIRD_TOKEN="$SHOREBIRD_TOKEN" && shorebird patch android
+```
+
+:::caution
+The `SHOREBIRD_TOKEN` is a secret and should not be committed directly in your source code or shared publicly.
+:::

--- a/docs/ci/codemagic.mdx
+++ b/docs/ci/codemagic.mdx
@@ -7,6 +7,8 @@ description: Integrate Shorebird into your Codemagic workflow
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import CIAuthentication from './_ci_authentication.md';
+
 :::info
 Codemagic recently published
 [their own guide](https://blog.codemagic.io/how-to-set-up-flutter-code-push-with-shorebird-and-codemagic/)
@@ -29,38 +31,7 @@ Refer to the [getting started](/) instructions for more information.
 
 ## Authentication
 
-Most Shorebird functionality, like creating releases and patches, requires being authenticated. In order to authenticate with Shorebird in CI, you will need to generate a CI token.
-
-```sh
-shorebird login:ci
-```
-
-You will be prompted to go through a similar OAuth Flow as when using `shorebird login`, however, `shorebird login:ci` will not store any credentials on your device. Instead, a Shorebird token will be generated for you to use in CI.
-
-The output should look something like:
-
-```sh
-$ shorebird login:ci
-The Shorebird CLI needs your authorization to manage apps, releases, and patches on your behalf.
-
-In a browser, visit this URL to log in:
-
-https://accounts.google.com/o/oauth2/v2/auth...
-
-Waiting for your authorization...
-
-🎉 Success! Use the following token to login on a CI server:
-
-<SHOREBIRD_TOKEN>
-
-Example:
-
-export SHOREBIRD_TOKEN="$SHOREBIRD_TOKEN" && shorebird patch android
-```
-
-:::caution
-The `SHOREBIRD_TOKEN` is a secret and should not be committed directly in your source code or shared publicly.
-:::
+<CIAuthentication />
 
 Next, copy the generated `SHOREBIRD_TOKEN` and navigate to your Codemagic
 secrets via:

--- a/docs/ci/github.mdx
+++ b/docs/ci/github.mdx
@@ -4,6 +4,8 @@ title: 🐙 GitHub
 description: Integrate Shorebird into your GitHub workflow
 ---
 
+import CIAuthentication from './_ci_authentication.md';
+
 # GitHub Workflow Integration
 
 The [Setup Shorebird](https://github.com/shorebirdtech/setup-shorebird) GitHub Action allows you to integrate Shorebird into your existing GitHub Workflows.
@@ -54,38 +56,7 @@ Currently `setup-shorebird` only supports the latest stable version of shorebird
 
 ## Authentication
 
-Most Shorebird functionality, like creating releases and patches, requires being authenticated. In order to authenticate with Shorebird in CI, you will need to generate a CI token.
-
-```sh
-shorebird login:ci
-```
-
-You will be prompted to go through a similar OAuth Flow as when using `shorebird login`, however, `shorebird login:ci` will not store any credentials on your device. Instead, a Shorebird token will be generated for you to use in CI.
-
-The output should look something like:
-
-```sh
-$ shorebird login:ci
-The Shorebird CLI needs your authorization to manage apps, releases, and patches on your behalf.
-
-In a browser, visit this URL to log in:
-
-https://accounts.google.com/o/oauth2/v2/auth...
-
-Waiting for your authorization...
-
-🎉 Success! Use the following token to login on a CI server:
-
-<SHOREBIRD_TOKEN>
-
-Example:
-
-export SHOREBIRD_TOKEN="$SHOREBIRD_TOKEN" && shorebird patch android
-```
-
-:::caution
-The `SHOREBIRD_TOKEN` is a secret and should not be committed directly in your source code or shared publicly.
-:::
+<CIAuthentication />
 
 Next, copy the generated `SHOREBIRD_TOKEN` and navigate to your GitHub repository secrets via:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -162,7 +162,7 @@ See also our privacy policy: https://shorebird.dev/privacy
 ### Can I use Shorebird from my CI system?
 
 Yes. Shorebird is intended to be used from CI systems. We've published a
-guide for [Github Actions](ci/github.md), other CI systems should be similar.
+guide for [Github Actions](ci/github.mdx), other CI systems should be similar.
 
 Please don't hesitate to reach out over GitHub issues or Discord if you
 encounter any issues.


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

This PR extracts the part of the docs that explain how to obtain a CI token in its own reusable file. Which then is used on both the github and codemagic guides. Removing the duplicated docs between both files.

This will make this section of the docs easier to scale as we add more content.

After this, I plan on adding to the `_ci_authentication.md` file about how the token can also be acquired from the console.
