### PR TITLE
docs: Adding explanation on docs about getting the ci token on the console

### DIFF
--- a/docs/ci/_ci_authentication.md
+++ b/docs/ci/_ci_authentication.md
@@ -1,5 +1,16 @@
 Most Shorebird functionality, like creating releases and patches, requires being authenticated. In order to authenticate with Shorebird in CI, you will need to generate a CI token.
 
+You can get a CI token via two methods: Using the Shorebird CLI or getting it through the Shorebird web console.
+
+### Shorebird Web Console
+
+While logged in the Shorebird web console, navigate to your `Account` and scroll down to the `CI Token` section.
+
+After reading the disclaimer, click in the `I understand, show my CI KEY` button to reveal your CI token and you can copy it from
+the interface.
+
+### Shorebird CLI
+
 ```sh
 shorebird login:ci
 ```


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Adds a quick explanation in the CI authentication section about getting the CI token from the web console.

Before this is merged, we need to push a deploy of the console so the feature is available.

<img width="904" alt="Screenshot 2024-04-09 at 10 00 28" src="https://github.com/shorebirdtech/docs/assets/835641/7196bd8b-0ccc-4f18-9499-09cfbfa6617b">

