### PR TITLE
fix: Action shorebird-release usage

### DIFF
--- a/docs/ci/github.mdx
+++ b/docs/ci/github.mdx
@@ -104,6 +104,8 @@ jobs:
 
       - name: 🚀 Shorebird Release
         uses: shorebirdtech/shorebird-release@v0
+        with:
+          platform: android # or 'ios'
 ```
 
 :::tip
@@ -113,6 +115,8 @@ The `shorebird-release` action also outputs the release version:
 - name: 🚀 Shorebird Release
   id: shorebird-release
   uses: shorebirdtech/shorebird-release@v0
+  with:
+    platform: android # or 'ios'
 
 - name: 📝 Output Release Version
   run: echo ${{ steps.shorebird-release.outputs.release-version }}


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

In the CI docs section the usage of the `shorebird-release` action was missing the required argument `platform`. This PR addresses that.
