### PR TITLE
docs: Adding section on release docs about the flutter version flag

### DIFF
--- a/docs/code_push/release.mdx
+++ b/docs/code_push/release.mdx
@@ -77,6 +77,18 @@ following command:
 shorebird release android --artifact apk
 ```
 
+:::info
+By default `shorebird release` uses the Flutter version bundled within the shorebird installation.
+
+That version can be checked by running `shorebird doctor`
+:::
+
+To release with a different Flutter version, you can specify the version using the `--flutter-version` flag.
+
+```sh
+shorebird release android --flutter-version 3.19.0
+```
+
 </TabItem>
 
 <TabItem value="release-output-ios" label="iOS">
@@ -128,6 +140,18 @@ need to put `flutter build` arguments after a `--` separator. For example:
 `shorebird release android -- --dart-define="foo=bar"` will define the `"foo"` environment
 variable inside Dart as you might have done with `flutter build` directly.
 :::
+
+:::info
+By default `shorebird release` uses the Flutter version bundled within the shorebird installation.
+
+That version can be checked by running `shorebird doctor`
+:::
+
+To release with a different Flutter version, you can specify the version using the `--flutter-version` flag.
+
+```sh
+shorebird release ios --flutter-version 3.19.0
+```
 
 </TabItem>
 


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Adds a brief section in the release command docs to mention about the `flutter-version` flag.
