### PR TITLE
Explain how to patch specific release version

### DIFF
--- a/docs/code_push/patch.mdx
+++ b/docs/code_push/patch.mdx
@@ -67,9 +67,17 @@ Would you like to continue? (y/N) Yes
 ✅ Published Patch!
 ```
 
+By default, this uses the release version that the app is currently on. If you
+want to patch a different release version, you can use the `--release-version`
+option. For example:
+
+```
+shorebird patch android --release-version 0.1.0+1
+```
+
 If your application supports flavors or multiple release targets, you can specify the flavor and target using the `--flavor` and `--target` options:
 
-```bash
+```
 shorebird patch [android|ios] --target lib/main_development.dart --flavor development
 ```
 

--- a/docs/code_push/release.mdx
+++ b/docs/code_push/release.mdx
@@ -73,7 +73,7 @@ By default, `shorebird release android` builds an AppBundle (`.aab`).
 If you would like to _also_ generate an Android Package Kit (`.apk`), use the
 following command:
 
-```bash
+```
 shorebird release android --artifact apk
 ```
 
@@ -85,7 +85,7 @@ That version can be checked by running `shorebird doctor`
 
 To release with a different Flutter version, you can specify the version using the `--flutter-version` flag.
 
-```sh
+```
 shorebird release android --flutter-version 3.19.0
 ```
 
@@ -129,7 +129,7 @@ To upload to the App Store either:
 
 If your application supports flavors or multiple release targets, you can specify the flavor and target using the `--flavor` and `--target` options:
 
-```bash
+```
 shorebird release ios --target ./lib/main_development.dart --flavor development
 ```
 
@@ -149,7 +149,7 @@ That version can be checked by running `shorebird doctor`
 
 To release with a different Flutter version, you can specify the version using the `--flutter-version` flag.
 
-```sh
+```
 shorebird release ios --flutter-version 3.19.0
 ```
 
@@ -186,7 +186,7 @@ program, but we expect it to work just as well.
 To build Shorebird for distribution via APK (e.g. side-loading), use the
 `--artifact` flag with the `shorebird release` command. For example:
 
-```bash
+```
 shorebird release android --artifact=apk
 ```
 


### PR DESCRIPTION
Adds note explaining how to patch a specific release version. Also removes `bash`/`sh` from some command snippets because it was causing weird syntax highlight with version numbers:

![Screenshot 2024-04-19 at 11 24 32 AM](https://github.com/shorebirdtech/docs/assets/581764/8f6c5b5d-aeea-4f32-9d0b-14f97c126318)
