### PR TITLE
docs: Removing know issues for ios link on status page

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -27,10 +27,6 @@ of your Dart code on the CPU. However there are still a few types of changes
 which can confuse the "linker" into running more code on the interpreter than
 necessary.
 
-Known linker issues include:
-
-- [Adding or removing a class can affect link percentage](https://github.com/shorebirdtech/shorebird/issues/1825)
-
 If your app has reported an unexpectedly low link percentage, please let us
 know, we'd love to help. You can report an issue here:
 https://github.com/shorebirdtech/shorebird/issues

--- a/docs/status.md
+++ b/docs/status.md
@@ -27,6 +27,10 @@ of your Dart code on the CPU. However there are still a few types of changes
 which can confuse the "linker" into running more code on the interpreter than
 necessary.
 
+Known linker issues include:
+
+- [iOS possible low link percentage](https://github.com/shorebirdtech/shorebird/issues/1892)
+
 If your app has reported an unexpectedly low link percentage, please let us
 know, we'd love to help. You can report an issue here:
 https://github.com/shorebirdtech/shorebird/issues


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Removing the known issues listing in the low ios linking percentage since that was solved in  `1.0.5`
