### PR TITLE
fix: fixed typo in architecture section

### DIFF
--- a/src/content/docs/architecture.mdx
+++ b/src/content/docs/architecture.mdx
@@ -89,7 +89,7 @@ also checks the hash of the patch diff to confirm download integrity.
 
 The hash is not meant to be a security feature, but rather a way to detect
 errors in the patch diff. A common error we see is that developers `shorebird
-release` with one source and then actually build an release a different binary,
+release` with one source and then actually build and release a different binary,
 resulting then in invalid patches. This hash helps detect such errors. We
 currently do not sign patches, but plan to add that capability in the near
 future.


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description
Fixed a typo in the documentation file **src/content/docs/architecture.mdx** :
 The word "an" was incorrectly used instead of "and" in the phrase "build and release a different binary."
<!--- Describe your changes in detail -->
