### PR TITLE
Replace :::info with :::note

### DIFF
--- a/src/content/docs/ci/codemagic.mdx
+++ b/src/content/docs/ci/codemagic.mdx
@@ -12,7 +12,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 import Authentication from './_authentication.mdx';
 
-:::info
+:::note
 Codemagic recently published
 [their own guide](https://blog.codemagic.io/how-to-set-up-flutter-code-push-with-shorebird-and-codemagic/)
 on how to integrate with Shorebird.
@@ -28,7 +28,7 @@ This guide will help you integrate Shorebird into your Codemagic Workflow using 
 
 ✅ You are logged into a Shorebird account.
 
-:::info
+:::note
 Refer to the [getting started](/) instructions for more information.
 :::
 

--- a/src/content/docs/ci/github.mdx
+++ b/src/content/docs/ci/github.mdx
@@ -18,7 +18,7 @@ The [Setup Shorebird](https://github.com/shorebirdtech/setup-shorebird) GitHub A
 
 ✅ You are logged into a Shorebird account.
 
-:::info
+:::note
 Refer to the [getting started](/) instructions for more information.
 :::
 
@@ -52,7 +52,7 @@ jobs:
 
 In the above workflow, we're using the `setup-shorebird` action to configure Shorebird in our CI and in subsequent steps we can execute any Shorebird commands.
 
-:::info
+:::note
 Currently `setup-shorebird` only supports the latest stable version of shorebird.
 :::
 

--- a/src/content/docs/code-push/initialize.mdx
+++ b/src/content/docs/code-push/initialize.mdx
@@ -81,11 +81,11 @@ flavors:
   production: 6b6e6631-4fbe-4645-8d9d-d5247656d975
 ```
 
-:::info
+:::note
 The `app_id` is a required field in every `shorebird.yaml`. In the case of flavors, `app_id` will default to the first flavor and will be overwritten at build time to the corresponding flavor's `app_id`.
 :::
 
-:::info
+:::note
 Shorebird code push requires the internet permission to be added to your
 `AndroidManifest.xml` file (located in
 `android/app/src/main/AndroidManifest.xml`). This is required for the app to be

--- a/src/content/docs/code-push/patch.mdx
+++ b/src/content/docs/code-push/patch.mdx
@@ -80,7 +80,7 @@ If your application supports flavors or multiple release targets, you can specif
 shorebird patch [android|ios] --target lib/main_development.dart --flavor development
 ```
 
-:::info
+:::note
 `shorebird patch` wraps `flutter build` and can take any argument
 `flutter build` can. To pass arguments to the underlying `flutter build` you
 need to put `flutter build` arguments after a `--` separator. For example:

--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -58,7 +58,7 @@ If your application supports flavors or multiple release targets, you can specif
 shorebird release android --target ./lib/main_development.dart --flavor development
 ```
 
-:::info
+:::note
 `shorebird release` wraps `flutter build` and can take any argument
 `flutter build` can. To pass arguments to the underlying `flutter build` you
 need to put `flutter build` arguments after a `--` separator. For example:
@@ -74,7 +74,7 @@ following command:
 shorebird release android --artifact apk
 ```
 
-:::info
+:::note
 By default `shorebird release` uses the Flutter version bundled within the shorebird installation.
 
 That version can be checked by running `shorebird doctor`
@@ -130,7 +130,7 @@ If your application supports flavors or multiple release targets, you can specif
 shorebird release ios --target ./lib/main_development.dart --flavor development
 ```
 
-:::info
+:::note
 `shorebird release` wraps `flutter build` and can take any argument
 `flutter build` can. To pass arguments to the underlying `flutter build` you
 need to put `flutter build` arguments after a `--` separator. For example:
@@ -138,7 +138,7 @@ need to put `flutter build` arguments after a `--` separator. For example:
 variable inside Dart as you might have done with `flutter build` directly.
 :::
 
-:::info
+:::note
 By default `shorebird release` uses the Flutter version bundled within the shorebird installation.
 
 That version can be checked by running `shorebird doctor`

--- a/src/content/docs/flutter-version.mdx
+++ b/src/content/docs/flutter-version.mdx
@@ -110,7 +110,7 @@ Android requires Flutter 3.10.0 or later.
 
 iOS requires Flutter 3.22.2 or later.
 
-:::info
+:::note
 We would like Shorebird to support to as many Flutter versions as possible. If
 there are older versions of Flutter which you need Shorebird to support, please
 [let us know](https://github.com/shorebirdtech/shorebird/issues/1100).

--- a/src/content/docs/guides/code-push-quickstart.mdx
+++ b/src/content/docs/guides/code-push-quickstart.mdx
@@ -55,7 +55,7 @@ contains your Shorebird `app_id`.
 
 This will also run `shorebird doctor` to ensure everything is set up correctly.
 
-:::info
+:::note
 Shorebird expects to find the latest stable `flutter` installed on your
 machine. Shorebird can be configured to work with older versions of Flutter
 (back to 3.10.0). See [Flutter Version Management](/flutter-version) for more

--- a/src/content/docs/guides/flavors/android.mdx
+++ b/src/content/docs/guides/flavors/android.mdx
@@ -14,7 +14,7 @@ This guide assumes the Shorebird command-line is installed on your machine and t
 
 ## Create a Project
 
-:::info
+:::note
 In this guide, we'll go through the process of creating a new project from scratch. To apply these changes to an existing project, skip this step and read ahead.
 :::
 
@@ -55,7 +55,7 @@ Lastly, edit `android/app/src/main/AndroidManifest.xml` to use the `applicationL
 +  <application android:label="${applicationLabel}" android:name="${applicationName}" android:icon="@mipmap/ic_launcher">
 ```
 
-:::info
+:::note
 To learn more about configuring `productFlavors` refer to the [Android Developer documentation](https://developer.android.com/build/build-variants#product-flavors).
 :::
 
@@ -114,7 +114,7 @@ This will download the releases and run them on your device.
 
 In addition to previewing the releases locally, you should also [submit the generated app bundles to the Play Store](/guides/release/android#upload-to-the-play-store). In this case, both apps can be part of the internal test flavor and only the stable variant should be promoted to production.
 
-:::info
+:::note
 
 - The `internal` variant should only be used for internal testing/validation.
 - The `stable` variant should be shipped to end users in production.
@@ -160,7 +160,7 @@ class MyApp extends StatelessWidget {
 }
 ```
 
-:::info
+:::note
 Typically `shorebird patch` should be used to fix critical bugs.
 :::
 

--- a/src/content/docs/guides/flavors/ios.mdx
+++ b/src/content/docs/guides/flavors/ios.mdx
@@ -14,7 +14,7 @@ This guide assumes the Shorebird command-line is installed on your machine and t
 
 ## Create a Project
 
-:::info
+:::note
 In this guide, we'll go through the process of creating a new project from scratch. To apply these changes to an existing project, skip this step and read ahead.
 :::
 
@@ -83,7 +83,7 @@ This will download the releases and run them on your device.
 
 In addition to previewing the releases locally, you should also [submit the generated app bundles to the App Store](/guides/release/ios#upload-to-the-app-store). In this case, both apps can be part of the internal test flavor and only the stable variant should be promoted to production.
 
-:::info
+:::note
 
 - The `internal` variant should only be used for internal testing/validation.
 - The `stable` variant should be shipped to end users in production.

--- a/src/content/docs/guides/hybrid-apps/ios.mdx
+++ b/src/content/docs/guides/hybrid-apps/ios.mdx
@@ -69,7 +69,7 @@ While there are multiple ways to embed a Flutter module in an iOS app, Shorebird
 requires that your Flutter module be embedded in your iOS app as an
 .xcframework.
 
-:::info
+:::note
 The steps to do this are the same as the
 [option B in the official instructions](https://docs.flutter.dev/add-to-app/ios/project-setup#option-b---embed-frameworks-in-xcode),
 so in the event of a conflict between the docs here and the official docs, defer

--- a/src/content/docs/guides/staging-patches.mdx
+++ b/src/content/docs/guides/staging-patches.mdx
@@ -13,7 +13,7 @@ This guide assumes the Shorebird command-line is installed on your machine and t
 
 ## Create a Project
 
-:::info
+:::note
 In this guide, we'll go through the process of creating a new project from scratch. To apply these changes to an existing project, skip this step and read ahead.
 :::
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -39,7 +39,7 @@ iwr -UseBasicParsing 'https://raw.githubusercontent.com/shorebirdtech/install/ma
   </TabItem>
 </Tabs>
 
-:::info
+:::note
 Installing Shorebird CLI requires `git`.
 :::
 
@@ -61,7 +61,7 @@ git clone -b stable https://github.com/shorebirdtech/shorebird.git
 
 Add the `bin` folder from the repository you just cloned into your `PATH`.
 
-:::info
+:::note
 The total installation is about 300mb.
 :::
 

--- a/src/content/docs/status.mdx
+++ b/src/content/docs/status.mdx
@@ -33,7 +33,7 @@ know, we'd love to help. You can report an issue here:
 https://github.com/shorebirdtech/shorebird/issues
 Or reach us via Discord: https://discord.gg/shorebird.
 
-:::info
+:::note
 Link percentage is not itself a great measure of performance. We've seen apps
 link only 30% and run smoothly, and other apps link 99.5% and struggle to run
 at 30fps. What matters is that the hot code paths in your app end up on the

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -212,7 +212,7 @@ mean that your patch will not work, but because shorebird cannot be sure that
 the changes are safe, and because shorebird can't patch non-Dart code, it prints
 a warning.
 
-:::info
+:::note
 Shorebird assumes a repeatable build -- if you build the application twice
 it ends up byte-for-byte identical (with a few minor known exceptions, like the
 certificate signing date for iOS apps). Some Flutter Plugins or obfuscation


### PR DESCRIPTION
Replaces instances of the unsupported `:::info` with the supported `:::note`.

See https://starlight.astro.build/guides/authoring-content/#asides for a list of supported asides/callouts/admonitions. 