### PR TITLE
docs: improve descriptions of the shorebird's url in the "can I use in my country faq"

### DIFF
--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -36,7 +36,7 @@ The following URLs are used by Shorebird:
 - https://download.shorebird.dev -- used by the `shorebird` command line tool to
   download Flutter artifacts for building releases and patches.
 - https://storage.googleapis.com -- used by the `shorebird` command line tool to
-  upload and download release and patch artifacts. As well by the Shorebird updater
+  upload and download release and patch artifacts, and by the Shorebird updater
   on user's devices to download the patches.
 
 If all of those URLs are accessible from your country, then Shorebird should work.

--- a/src/content/docs/faq.mdx
+++ b/src/content/docs/faq.mdx
@@ -36,7 +36,8 @@ The following URLs are used by Shorebird:
 - https://download.shorebird.dev -- used by the `shorebird` command line tool to
   download Flutter artifacts for building releases and patches.
 - https://storage.googleapis.com -- used by the `shorebird` command line tool to
-  upload and download release and patch artifacts.
+  upload and download release and patch artifacts. As well by the Shorebird updater
+  on user's devices to download the patches.
 
 If all of those URLs are accessible from your country, then Shorebird should work.
 


### PR DESCRIPTION

<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Felt the description on the `https://storage.googleapis.com/` url on the section `Can I use in my country?` section of the FAQ was missing the updater part.
