### PR TITLE
Add sentry integration guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -110,6 +110,12 @@ export default defineConfig({
           },
         },
         {
+          label: 'Crash Reporting',
+          autogenerate: {
+            directory: 'guides/crash-reporting',
+          },
+        },
+        {
           label: 'Flutter Version',
           link: '/flutter-version',
         },

--- a/src/content/docs/guides/crash-reporting/sentry.mdx
+++ b/src/content/docs/guides/crash-reporting/sentry.mdx
@@ -1,0 +1,49 @@
+---
+title: Sentry Integration
+description: Integrate Shorebird into your Sentry crash reporting
+sidebar:
+  label: Sentry
+  order: 1
+---
+
+If you're using Sentry for crash reporting, it will work out-of-the-box with
+Shorebird releases and patches. However, if you have multiple patches, it can be
+unclear which patch caused the crash. This document shows how you can use Sentry
+tags to differentiate between patches.
+
+## Add the `shorebird_code_push` package to your project.
+
+[shorebird_code_push](https://pub.dev/packages/shorebird_code_push) is available
+on pub.dev and lets you programmatically determine your app's current patch
+number. To add it to your project, follow the instructions on the package's
+pub.dev page.
+
+## Configure Sentry
+
+If you haven't already, follow the Sentry [getting started with
+Flutter](https://docs.sentry.io/platforms/flutter/) guide.
+
+Update the Sentry init code to include the patch number as a tag. This will look
+something like:
+
+```dart
+Future<void> main() async {
+  // Get the current patch number. This will be null if no patch is installed.
+  final patchNumber = await ShorebirdCodePush().currentPatchNumber();
+
+  await SentryFlutter.init(
+    (options) {
+      options.dsn = 'YOUR_DSN';
+    },
+    appRunner: ()
+      // Add the patch number as a tag. You can use whatever name you would like
+      // as the key. `$patchNumber` will be "null" if there is no patch. You may
+      // wish to handle this case differently.
+      Sentry.configureScope((scope) {
+        scope.setTag('shorebird_patch_number', '$patchNumber');
+      });
+      return runApp(const MyApp());
+    ,
+  );
+}
+```

--- a/src/content/docs/guides/crash-reporting/sentry.mdx
+++ b/src/content/docs/guides/crash-reporting/sentry.mdx
@@ -35,7 +35,7 @@ Future<void> main() async {
     (options) {
       options.dsn = 'YOUR_DSN';
     },
-    appRunner: ()
+    appRunner: () {
       // Add the patch number as a tag. You can use whatever name you would like
       // as the key. `$patchNumber` will be "null" if there is no patch. You may
       // wish to handle this case differently.

--- a/src/content/docs/guides/crash-reporting/sentry.mdx
+++ b/src/content/docs/guides/crash-reporting/sentry.mdx
@@ -43,7 +43,7 @@ Future<void> main() async {
         scope.setTag('shorebird_patch_number', '$patchNumber');
       });
       return runApp(const MyApp());
-    ,
+    },
   );
 }
 ```


### PR DESCRIPTION
## Status

**READY**

## Description

Adds a guide explaining how to include patch numbers in Sentry error reports. 

Addresses the Sentry part of https://github.com/shorebirdtech/shorebird/issues/2258. I suspect the Crashlytics guide will be very similar.
