### PR TITLE
docs: update our version docs for 3.22.3

### DIFF
--- a/src/content/docs/flutter-version.mdx
+++ b/src/content/docs/flutter-version.mdx
@@ -16,21 +16,9 @@ changes to previous release of Flutter.
 :::
 
 Shorebird supports creating a release with older versions of Flutter (back to
-3.10.0 for Android or 3.22.2 for iOS), a release created with one of these
+3.10.0 for Android or 3.22.3 for iOS), a release created with one of these
 versions may not contain all of the most recent Shorebird features. Because of
 this, we recommend using the latest stable version of Flutter whenever possible.
-
-:::danger
-We found and fixed a bug in the Dart runtime, whereby sometimes "catch" blocks
-would be ignored after applying a Shorebird patch. This bug has been present in
-all versions of Shorebird Flutter for iOS prior to 3.22.2. This bug did not
-affect Android.
-
-After careful evaluation we decided this try/catch issue was severe enough that
-we would be remiss to allow continued use of older versions of Flutter for iOS
-releases. We have therefore decided to only support Flutter 3.22.2 and later
-for iOS releases at this time.
-:::
 
 ## List Flutter Versions
 
@@ -39,7 +27,9 @@ To list all Flutter versions Shorebird has published, use the
 
 ```
 $ shorebird flutter versions list
-✓ 3.22.2
+📦 Flutter Versions
+✓ 3.22.3
+  3.22.2
   3.22.1
   3.22.0
   3.19.6
@@ -75,7 +65,7 @@ $ shorebird flutter versions list
 ```
 
 :::note
-The current Flutter version used by your Shorebird CLI installation will be marked with a `✓`.
+The Flutter version used by `shorebird release` by default is marked with a `✓`.
 :::
 
 :::tip
@@ -108,13 +98,7 @@ Android requires Flutter 3.10.0 or later.
 
 `package:shorebird_code_push` requires Flutter 3.10.6 or later.
 
-iOS requires Flutter 3.22.2 or later.
-
-:::note
-We would like Shorebird to support to as many Flutter versions as possible. If
-there are older versions of Flutter which you need Shorebird to support, please
-[let us know](https://github.com/shorebirdtech/shorebird/issues/1100).
-:::
+iOS requires Flutter 3.22.3 or later.
 
 ### Disabled Flutter Versions
 


### PR DESCRIPTION
I moved our "min supported" version to 3.22.3 for iOS even though
the tool will actually let your release on 3.22.2 as well.

3.22.3 and 3.22.2 are very similar in code from upstream, but the
3.22.3 from us includes a much improved linker.