### PR TITLE
Fix typo on status page

### DIFF
--- a/src/content/docs/status.mdx
+++ b/src/content/docs/status.mdx
@@ -9,7 +9,9 @@ Issues affecting some customers:
 
 - `--obfuscate` does not work with iOS builds on Shorebird.
   https://github.com/shorebirdtech/shorebird/issues/1619
-- Would like to share groups of apps with my company: https://github.com/shorebirdtech/shorebird/issues/739 (For now, can help you do this via our support email see https://docs.shorebird.dev/teams/).
+- Would like to share groups of apps with my company:
+  https://github.com/shorebirdtech/shorebird/issues/739 (For now, we can help
+  you do this via our support email see https://docs.shorebird.dev/teams/).
 
 A full list of reported issues and feature requests is available on GitHub:
 https://github.com/shorebirdtech/shorebird/


### PR DESCRIPTION
"For now, can help" -> "For now, we can help"