### PR TITLE
fix: update hybrid android guide to fix hash mismatch issue

### DIFF
--- a/src/content/docs/guides/hybrid-apps/android.mdx
+++ b/src/content/docs/guides/hybrid-apps/android.mdx
@@ -97,8 +97,12 @@ In `app/build.gradle`, add the following:
 buildTypes {
     release {
         // ...
-+        // Necessary to ensure the libapp.so produced by Shorebird matches the one that ends up
-+        // in the APK.
++        // The Dart compiler builds libapp.so directly (does not use clang),and already strips
++        // symbols. However when llvm-strip is run on libapp.so, the symbols are re-sorted
++        // causing the hash of the library to change (which can confuse Shorebird tools).
++        // This line tells gradle to skip the unnecessary llvm-strip step for libapp.so
++        // thus ensuring that the libapp.so that Shorebird sees is byte-identical to the one
++        // which ends up in the APK/AAR/AAB.
 +        packaging.jniLibs.keepDebugSymbols.add("**/libapp.so")
         // ...
     }

--- a/src/content/docs/guides/hybrid-apps/android.mdx
+++ b/src/content/docs/guides/hybrid-apps/android.mdx
@@ -94,6 +94,16 @@ versions of Flutter that Shorebird supports.
 In `app/build.gradle`, add the following:
 
 ```diff
+buildTypes {
+    release {
+        // ...
++        // Necessary to ensure the libapp.so produced by Shorebird matches the one that ends up
++        // in the APK.
++        packaging.jniLibs.keepDebugSymbols.add("**/libapp.so")
+        // ...
+    }
+}
+
 dependencies {
     // ...
 +    releaseImplementation 'com.example.my_flutter_module:flutter_release:1.0'


### PR DESCRIPTION
## Status

**READY**

## Description

Update guide to include `packaging.jniLibs.keepDebugSymbols.add("**/libapp.so")` to prevent hash mismatches when using `compileSdk 34`.

Fixes https://github.com/shorebirdtech/shorebird/issues/2369