### PR TITLE
docs: Update our teams documentation

### DIFF
--- a/src/content/docs/teams.mdx
+++ b/src/content/docs/teams.mdx
@@ -66,18 +66,6 @@ The Admin role can:
 - Add and Remove Developers for an App
 - Delete Apps
 - Delete Releases
-  Admin permissions cannot currently be modified in the console. Please email us
-  if you need to add/remove Admins from an app.
-
-#### Adding an Admin
-
-To make a developer an admin on your app, first make sure they have created
-a Shorebird account. You can then add them as a collaborator via the console
-for any apps you wish. After that, to make them an admin, you'll currently need
-to reach out to us at contact@shorebird.dev and we're happy to adjust their
-status from "Developer" to "Admin" on any apps you desire.
-
-See https://github.com/shorebirdtech/shorebird/issues/2477
 
 ## Account Owner
 


### PR DESCRIPTION
Remove `Adding an Admin` request from docs as it can currently be done in the console.