### PR TITLE
Add note explaining preview params are optional

### DIFF
--- a/src/content/docs/guides/flavors/android.mdx
+++ b/src/content/docs/guides/flavors/android.mdx
@@ -110,6 +110,13 @@ shorebird preview --app-id ee322dc4-3dc2-4324-90a9-04c40a62ae76 --release-versio
 shorebird preview --app-id 904bd3d5-3526-4c1c-a832-7ac23c95302d --release-version 1.0.0+1
 ```
 
+:::note
+
+`--app-id` and `--release-version` are optional parameters. If not provided, you
+will be prompted to select the app and release version interactively.
+
+:::
+
 This will download the releases and run them on your device.
 
 In addition to previewing the releases locally, you should also [submit the

--- a/src/content/docs/guides/flavors/ios.mdx
+++ b/src/content/docs/guides/flavors/ios.mdx
@@ -79,6 +79,13 @@ shorebird preview --app-id ee322dc4-3dc2-4324-90a9-04c40a62ae76 --release-versio
 shorebird preview --app-id 904bd3d5-3526-4c1c-a832-7ac23c95302d --release-version 1.0.0+1
 ```
 
+:::note
+
+`--app-id` and `--release-version` are optional parameters. If not provided, you
+will be prompted to select the app and release version interactively.
+
+:::
+
 This will download the releases and run them on your device.
 
 In addition to previewing the releases locally, you should also [submit the


### PR DESCRIPTION
Adding a note explaining that the parameters to `shorebird preview` shown in our flavors docs are optional to address confusion like https://github.com/shorebirdtech/shorebird/issues/2549#issuecomment-2433464261