### PR TITLE
docs: Add a page on billing.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -141,6 +141,10 @@ export default defineConfig({
           link: '/status',
         },
         {
+          label: 'Billing',
+          link: '/billing',
+        },
+        {
           label: 'Architecture',
           link: '/architecture',
         },

--- a/src/content/docs/billing.mdx
+++ b/src/content/docs/billing.mdx
@@ -1,0 +1,35 @@
+---
+title: Billing
+description: How Shorebird handles Billing
+---
+
+Shorebird uses Stripe for all billing. We accept payment in any method
+that Stripe accepts.
+
+Annual billing, invoice billing and other payment methods are also available to
+customers purchasing over 1M patches per month, or custom enterprise plans. See
+our [pricing page](https://shorebird.dev/pricing) for more information.
+
+The Shorebird Pro plan costs $20 per month, which is billed monthly, at the
+beginning of each billing cycle, starting with time of purchase.
+
+Shorebird charges based on successful patch installs. Which are reported from
+your app to Shorebird servers on successful launch of your application with
+a newly installed patch.
+
+The Shorebird Pro plan includes 50,000 patch installs and supports optional
+overage billing for installs beyond 50,000.
+
+See [our blog](https://shorebird.dev/blog/simplified-pricing/) for instructions
+on how to enable overage billing.
+
+Overages will appear on the next month's invoice. So for example, say that you
+purchase a Pro plan, but use 100,000 patches every month.
+
+- You will be billed $20 at time of purchase (Month 1)
+- Month 2 and forward you will be billed for the 50,000 for the current month,
+  as well as the 50,000 overages from the previous month, for a total of $40.
+
+You can view records of patch installs in [your accounts
+page](https://console.shorebird.dev/account) on the Shorebird Console. These
+numbers are updated hourly.


### PR DESCRIPTION
Eventually we should probably move the content from https://shorebird.dev/blog/simplified-pricing/ into this page.