### PR TITLE
Add section about export options plist

### DIFF
--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -151,6 +151,57 @@ To release with a different Flutter version, you can specify the version using t
 shorebird release ios --flutter-version 3.19.0
 ```
 
+### Signing issues
+
+Depending on how you normally sign your iOS app, you may see an error at the end
+of the build saying something like: `Runner.app requries a provisioning profile
+with ___ feature` or that no signing certificate was found. This can be
+addressed in a few ways:
+
+#### Setting up automatic signing in Xcode
+
+If you are releasing on your local machine (i.e., not in a CI environment), this
+option is easier than the following options, but does not always work well in CI
+environments.
+
+In Xcode, open your project and navigate to the "Signing & Capabilities" tab.
+Ensure that "Automatically manage signing" is checked.
+
+#### Create an ExportOptions.plist file.
+
+You may need to provide an ExportOptions.plist file to the `shorebird release
+ios` command. This file is used by Xcode to determine which certificate and
+provisioning profile should be used to sign the .ipa. An example of this file
+is:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.example.your_bundle_id</key>
+		<string>Your App's App Store Distribution Certificate Name</string>
+	</dict>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>teamID</key>
+	<string>*****</string> # From https://developer.apple.com/account
+</dict>
+</plist>
+```
+
+To use this file, pass it to the `shorebird release ios` command:
+
+```sh
+shorebird release ios --export-options=path/to/ExportOptions.plist
+```
+
 </TabItem>
 
 </Tabs>

--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -154,7 +154,7 @@ shorebird release ios --flutter-version 3.19.0
 ### Signing issues
 
 Depending on how you normally sign your iOS app, you may see an error at the end
-of the build saying something like: `Runner.app requries a provisioning profile
+of the build saying something like: `Runner.app requires a provisioning profile
 with ___ feature` or that no signing certificate was found. This can be
 addressed in a few ways:
 

--- a/src/content/docs/troubleshooting.mdx
+++ b/src/content/docs/troubleshooting.mdx
@@ -315,6 +315,11 @@ to check which Java version works with which Gradle release.
 - Or try Installing the required Java version for your project's Gradle release and set
   the path where it was installed in the `JAVA_HOME` environment variable.
 
+## When creating an iOS release, I see an error saying that I'm missing a provisioning profile or that no signing team was found.
+
+We address this issue in our [releasing guide](/code-push/release). Take a look
+at the iOS section for more information.
+
 ## Have a problem that's not addressed here?
 
 We're happy to help on [Discord](https://discord.gg/shorebird)!


### PR DESCRIPTION
Adds a section to our iOS releasing docs explaining how to use export options plist files. This is in response to the recent uptick in support questions about this topic.