### PR TITLE
Replaces ShorebirdCodePush in favor of ShorebirdUpdater

### DIFF
--- a/src/content/docs/guides/crash-reporting/Integrations/crashlytics.mdx
+++ b/src/content/docs/guides/crash-reporting/Integrations/crashlytics.mdx
@@ -36,7 +36,7 @@ Future<void> main() async {
   final patch = await ShorebirdUpdater().readCurrentPatch();
 
   // Add the patch number as a tag. You can use whatever name you would like
-  // as the key. `${patch?.number}` will be "null" if there is no patch. You may
+  // as the key. `$patch` will be "null" if there is no patch. You may
   // wish to handle this case differently.
   FirebaseCrashlytics.instance.setCustomKey(
     'shorebird_patch_number',

--- a/src/content/docs/guides/crash-reporting/Integrations/crashlytics.mdx
+++ b/src/content/docs/guides/crash-reporting/Integrations/crashlytics.mdx
@@ -33,14 +33,14 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  final patchNumber = await ShorebirdCodePush().currentPatchNumber();
+  final patchNumber = await ShorebirdUpdater().readCurrentPatch();
 
   // Add the patch number as a tag. You can use whatever name you would like
-  // as the key. `$patchNumber` will be "null" if there is no patch. You may
+  // as the key. `${patchNumber?.number}` will be "null" if there is no patch. You may
   // wish to handle this case differently.
   FirebaseCrashlytics.instance.setCustomKey(
     'shorebird_patch_number',
-    '$patchNumber',
+    '${patchNumber?.number}',
   );
   runApp(const MyApp());
 }

--- a/src/content/docs/guides/crash-reporting/Integrations/crashlytics.mdx
+++ b/src/content/docs/guides/crash-reporting/Integrations/crashlytics.mdx
@@ -33,14 +33,14 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  final patchNumber = await ShorebirdUpdater().readCurrentPatch();
+  final patch = await ShorebirdUpdater().readCurrentPatch();
 
   // Add the patch number as a tag. You can use whatever name you would like
-  // as the key. `${patchNumber?.number}` will be "null" if there is no patch. You may
+  // as the key. `${patch?.number}` will be "null" if there is no patch. You may
   // wish to handle this case differently.
   FirebaseCrashlytics.instance.setCustomKey(
     'shorebird_patch_number',
-    '${patchNumber?.number}',
+    '${patch?.number}',
   );
   runApp(const MyApp());
 }

--- a/src/content/docs/guides/crash-reporting/Integrations/sentry.mdx
+++ b/src/content/docs/guides/crash-reporting/Integrations/sentry.mdx
@@ -37,7 +37,7 @@ Future<void> main() async {
     },
     appRunner: () {
       // Add the patch number as a tag. You can use whatever name you would like
-      // as the key. `${patch?.number}` will be "null" if there is no patch. You may
+      // as the key. `$patch` will be "null" if there is no patch. You may
       // wish to handle this case differently.
       Sentry.configureScope((scope) {
         scope.setTag('shorebird_patch_number', '${patch?.number}',);

--- a/src/content/docs/guides/crash-reporting/Integrations/sentry.mdx
+++ b/src/content/docs/guides/crash-reporting/Integrations/sentry.mdx
@@ -29,7 +29,7 @@ something like:
 ```dart
 Future<void> main() async {
   // Get the current patch number. This will be null if no patch is installed.
-  final patchNumber = await ShorebirdUpdater().readCurrentPatch();
+  final patch = await ShorebirdUpdater().readCurrentPatch();
 
   await SentryFlutter.init(
     (options) {
@@ -37,10 +37,10 @@ Future<void> main() async {
     },
     appRunner: () {
       // Add the patch number as a tag. You can use whatever name you would like
-      // as the key. `${patchNumber?.number}` will be "null" if there is no patch. You may
+      // as the key. `${patch?.number}` will be "null" if there is no patch. You may
       // wish to handle this case differently.
       Sentry.configureScope((scope) {
-        scope.setTag('shorebird_patch_number', '${patchNumber?.number}',);
+        scope.setTag('shorebird_patch_number', '${patch?.number}',);
       });
       return runApp(const MyApp());
     },

--- a/src/content/docs/guides/crash-reporting/Integrations/sentry.mdx
+++ b/src/content/docs/guides/crash-reporting/Integrations/sentry.mdx
@@ -29,7 +29,7 @@ something like:
 ```dart
 Future<void> main() async {
   // Get the current patch number. This will be null if no patch is installed.
-  final patchNumber = await ShorebirdCodePush().currentPatchNumber();
+  final patchNumber = await ShorebirdUpdater().readCurrentPatch();
 
   await SentryFlutter.init(
     (options) {
@@ -37,10 +37,10 @@ Future<void> main() async {
     },
     appRunner: () {
       // Add the patch number as a tag. You can use whatever name you would like
-      // as the key. `$patchNumber` will be "null" if there is no patch. You may
+      // as the key. `${patchNumber?.number}` will be "null" if there is no patch. You may
       // wish to handle this case differently.
       Sentry.configureScope((scope) {
-        scope.setTag('shorebird_patch_number', '$patchNumber');
+        scope.setTag('shorebird_patch_number', '${patchNumber?.number}',);
       });
       return runApp(const MyApp());
     },

--- a/src/content/docs/update-strategies.mdx
+++ b/src/content/docs/update-strategies.mdx
@@ -88,8 +88,8 @@ are applied to releases, rather than being new releases themselves. This can
 complicate your analytics/reporting code as you will have the case where e.g.
 `1.0.1+13, patch 1` has identical dart code to `1.0.1+13, no patches`. You can
 get the current booted patch number via `package:shorebird_code_push`'s
-[currentPatchNumber]
-(https://pub.dev/documentation/shorebird_code_push/latest/shorebird_code_push/ShorebirdCodePush/currentPatchNumber.html)
+[readCurrentPatch]
+(https://pub.dev/documentation/shorebird_code_push/latest/shorebird_code_push/ShorebirdUpdater/readCurrentPatch.html)
 method.
 
 Shorebird also currently makes the guarantee that we do not see or store your


### PR DESCRIPTION
Hi! Just happened to notice deprecated methods in your docs.

## Status

**READY**

## Description
The Crashlytics and Sentry Integration pages contained outdated methods that have been replaced in the shorebird_code_push plugin v2.0.0-dev.1. 

I've also replaced a dead link on the Update Strategies page that pointed to the same method, which no longer exists.