### PR TITLE
fix: Add link explaining string asset support as generated code

### DIFF
--- a/src/content/docs/code-push/overview.mdx
+++ b/src/content/docs/code-push/overview.mdx
@@ -52,7 +52,7 @@ be applied over-the-air.
 Patches can change any Dart code in your application. This includes:
 
 - App code
-- Generated code
+- Generated code (including `app_localizations` if following the recommended [Internationalization Approach](https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization)
 - Dependencies in `pubspec.yaml`, as long as they don't include native code
   changes.
 


### PR DESCRIPTION
## Status

**READY**

## Description

There was some confusion around `.arb` files and if they could be updated using Shorebird. Given that `.arb` files are assets we can understand the confusion but need to remember that these files are not actually included in the application bundle and are instead used to generate Dart code. Therefore this falls under the "Generated code" item we have in the docs already.

Adding a note that will point to the Flutter Internationalization documentation to help solve this confusion.
