### PR TITLE
fix: removing duplicate section from security page

### DIFF
--- a/src/content/docs/system/security.mdx
+++ b/src/content/docs/system/security.mdx
@@ -316,25 +316,6 @@ Shorebird's product allows you, and only you, to update the code of your
 application on end user devices. We do not collect or wish to collect any
 information from these users or devices.
 
-## Suppliers
-
-We use a number of third party services to run our business. We list those which
-may come in contact with customer data as part of our privacy policy:
-https://shorebird.dev/privacy
-
-### Third Party Service Accounts
-
-Accounts are bucketed into having handling customer data (e.g. Google Cloud) or
-not (e.g. Canva).
-
-- All accounts and services we use are logged in our Accounts sheet.
-- All accounts should authenticate through Google OAuth (SSO). Exceptions must
-  be approved by the CEO.
-- Accounts that can never reach customer data (e.g. Twitter), may alternatively
-  use a strong password stored in 1Password and two factor authentication if SSO
-  is not available.
-- Additions to the Accounts sheet are reviewed by the CEO.
-
 ## Third-Party Assessments
 
 We have no third party security, network or otherwise assessments to share at


### PR DESCRIPTION
## Status

**READY**

## Description

Called out in the review for https://github.com/shorebirdtech/handbook/pull/50. This section was duplicated between docs and handbook. Its more company overarching so removing it from docs.
