### PR TITLE
feat: add support for image zoom

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightLinksValidator from 'starlight-links-validator';
 import starlightAutoSidebar from 'starlight-auto-sidebar';
-import starlightImageZoom from 'starlight-image-zoom'
+import starlightImageZoom from 'starlight-image-zoom';
 
 const site = 'https://docs.shorebird.dev/';
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightLinksValidator from 'starlight-links-validator';
 import starlightAutoSidebar from 'starlight-auto-sidebar';
+import starlightImageZoom from 'starlight-image-zoom'
 
 const site = 'https://docs.shorebird.dev/';
 
@@ -75,6 +76,7 @@ export default defineConfig({
       ],
       plugins: [
         starlightAutoSidebar(),
+        starlightImageZoom(),
         starlightLinksValidator({
           errorOnFallbackPages: false,
           errorOnInconsistentLocale: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "astro": "^5.7.4",
         "sharp": "^0.34.1",
         "starlight-auto-sidebar": "^0.1.1",
+        "starlight-image-zoom": "^0.12.0",
         "tailwindcss": "^4.1.4",
         "typescript": "^5.8.3"
       },
@@ -6839,6 +6840,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.17.1"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.32.0"
+      }
+    },
+    "node_modules/starlight-image-zoom": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/starlight-image-zoom/-/starlight-image-zoom-0.12.0.tgz",
+      "integrity": "sha512-Zt9DuqXEw4JBBRc67wL9EP7DE9cSa+o2nyjQU6Xq+gRp388Wcu9C9FPROLuaYXbxpE93bbj5oyrhhMaiEWOZzg==",
+      "dependencies": {
+        "mdast-util-mdx-jsx": "^3.1.3",
+        "rehype-raw": "^7.0.0",
+        "unist-util-visit": "^5.0.0",
+        "unist-util-visit-parents": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.32.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "astro": "^5.7.4",
     "sharp": "^0.34.1",
     "starlight-auto-sidebar": "^0.1.1",
+    "starlight-image-zoom": "^0.12.0",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3"
   },


### PR DESCRIPTION
### Status
**READY**

### Description
Integration of the `starlight-image-zoom` library to enable image zoom on click.
Closes https://github.com/shorebirdtech/docs/issues/240.
