### PR TITLE
fix: fix github url

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,7 +23,7 @@ export default defineConfig({
         {
           icon: 'github',
           label: 'GitHub',
-          href: 'https://github.com/shorebirdtech/handbook',
+          href: 'https://github.com/shorebirdtech/docs',
         },
         {
           icon: 'discord',


### PR DESCRIPTION
## Status

**READY**

## Description

I think this was a copy/pasta error from when I did the update on handbook

