### PR TITLE
fix: add statement on release-version latest

### DIFF
--- a/src/content/docs/code-push/patch.mdx
+++ b/src/content/docs/code-push/patch.mdx
@@ -91,8 +91,15 @@ Would you like to continue? (y/N) Yes
 ```
 
 By default, this uses the release version that the app is currently on. If you
-want to patch a different release version, you can use the `--release-version`
-option. For example:
+want to explicitly state this you can use the `--release-version latest` option.
+For example:
+
+```
+shorebird patch android --release-version latest
+```
+
+If you want to patch a different release version, you can use the
+`--release-version` option. For example:
 
 ```
 shorebird patch android --release-version 0.1.0+1

--- a/src/content/docs/code-push/patch.mdx
+++ b/src/content/docs/code-push/patch.mdx
@@ -90,9 +90,9 @@ Would you like to continue? (y/N) Yes
 ✅ Published Patch!
 ```
 
-By default, this uses the release version that the app is currently on. If you
-want to explicitly state this you can use the `--release-version latest` option.
-For example:
+By default, this uses the release version from the compiled artifact. If you
+want to target the latest release version, you can use
+`--release-version latest`. For example:
 
 ```
 shorebird patch android --release-version latest


### PR DESCRIPTION
## Status

**READY**

## Description

Adding in some language specifically stating the `--release-version latest` flag for patches.
