### PR TITLE
fix: update example links in Uploading Symbols for Crash Reporting

### DIFF
--- a/src/content/docs/code-push/crash-reporting/uploading-symbols.mdx
+++ b/src/content/docs/code-push/crash-reporting/uploading-symbols.mdx
@@ -39,26 +39,26 @@ the symbols. This hash is displayed in `shorebird doctor` output:
 
 ```
 $ shorebird doctor
-Shorebird 0.24.1 • git@github.com:shorebirdtech/shorebird.git
-Flutter 3.16.7 • revision ba46e8490348d6989283c9cff2b95727f0969d04
-Engine • revision 974eae888fdedd890b74c84e55a454bb7fcbd7de
+Shorebird 1.6.49 • git@github.com:shorebirdtech/shorebird.git
+Flutter 3.32.5 • revision 44a8ada33bdbe7f25a49e7dcf13c5c1f648129fd
+Engine • revision f275acddf709f94ef38af54adb2c1a0a0a90b5c6
 ```
 
-In this case, we're using `974eae888fdedd890b74c84e55a454bb7fcbd7de` as the
+In this case, we're using `f275acddf709f94ef38af54adb2c1a0a0a90b5c6` as the
 engine hash.
 
 ## Symbols for iOS
 
-Assuming engine hash `974eae888fdedd890b74c84e55a454bb7fcbd7de`, the iOS symbols
+Assuming engine hash `f275acddf709f94ef38af54adb2c1a0a0a90b5c6`, the iOS symbols
 can be downloaded from the following URL:
 
-https://download.shorebird.dev/flutter_infra_release/flutter/974eae888fdedd890b74c84e55a454bb7fcbd7de/ios-release/Flutter.dSYM.zip
+https://storage.googleapis.com/download.shorebird.dev/flutter_infra_release/flutter/f275acddf709f94ef38af54adb2c1a0a0a90b5c6/ios-release/Flutter.framework.dSYM.zip
 
 ## Symbols for Android
 
-Assuming engine hash `974eae888fdedd890b74c84e55a454bb7fcbd7de`, the Android
+Assuming engine hash `f275acddf709f94ef38af54adb2c1a0a0a90b5c6`, the Android
 symbols can be downloaded from the following URLs:
 
-https://download.shorebird.dev/flutter_infra_release/flutter/974eae888fdedd890b74c84e55a454bb7fcbd7de/android-arm64-release/symbols.zip
-https://download.shorebird.dev/flutter_infra_release/flutter/974eae888fdedd890b74c84e55a454bb7fcbd7de/android-arm-release/symbols.zip
-https://download.shorebird.dev/flutter_infra_release/flutter/974eae888fdedd890b74c84e55a454bb7fcbd7de/android-x64-release/symbols.zip
+https://download.shorebird.dev/flutter_infra_release/flutter/f275acddf709f94ef38af54adb2c1a0a0a90b5c6/android-arm64-release/symbols.zip
+https://download.shorebird.dev/flutter_infra_release/flutter/f275acddf709f94ef38af54adb2c1a0a0a90b5c6/android-arm-release/symbols.zip
+https://download.shorebird.dev/flutter_infra_release/flutter/f275acddf709f94ef38af54adb2c1a0a0a90b5c6/android-x64-release/symbols.zip


### PR DESCRIPTION
## Changelog
* Rename iOS symbols from `Flutter.dSYM.zip` to `Flutter.framework.dSYM.zip`
* Point directly to storage for iOS since download.shorebird.dev isn't working. (Android links work fine)

## Description
I was following https://docs.shorebird.dev/code-push/crash-reporting/uploading-symbols and found that the iOS format no longer holds. Updated the examples.

I'm not sure if https://download.shorebird.dev/flutter_infra_release/flutter/f275acddf709f94ef38af54adb2c1a0a0a90b5c6/ios-release/Flutter.framework.dSYM.zip is supposed to work, but that gets `Unrecognized artifact path`. Using [Flutter.dSYM.zip](https://storage.googleapis.com/download.shorebird.dev/flutter_infra_release/flutter/f275acddf709f94ef38af54adb2c1a0a0a90b5c6/ios-release/Flutter.dSYM.zip) gets `<Code>NoSuchKey</Code>`.

Updated to working link: https://storage.googleapis.com/download.shorebird.dev/flutter_infra_release/flutter/f275acddf709f94ef38af54adb2c1a0a0a90b5c6/ios-release/Flutter.framework.dSYM.zip