### PR TITLE
fix: update headings on update strategies

### DIFF
--- a/src/content/docs/code-push/update-strategies.mdx
+++ b/src/content/docs/code-push/update-strategies.mdx
@@ -49,7 +49,7 @@ for you to check for updates as part of a login screen, or other launch gate.
 
 :::
 
-# Triggering updates via notification
+## Triggering updates via notification
 
 It is possible to trigger updates via push notifications.
 
@@ -67,7 +67,7 @@ will update if it is not already running.
 If you are manually managing updates with the `shorebird_code_push` package, you
 can check for and trigger updates in your notification handler.
 
-# How should Shorebird interact with other update systems (e.g. `in_app_update`)?
+## How should Shorebird interact with other update systems (e.g. `in_app_update`)?
 
 For applications that already ensure users are on the latest version (e.g. with
 `in_app_update`, a system on Android whereby the Play Store will automatically
@@ -100,7 +100,7 @@ Shorebird also currently makes the guarantee that we do not see or store your
 code. Implementing "push to deploy" may not be possible without source code
 access, which is not a change we would make lightly.
 
-# Can I update my app without starting it twice?
+## Can I update my app without starting it twice?
 
 The short answer, is no.
 


### PR DESCRIPTION
## Status

**READY**

## Description

Some incorrect markdown headings were making the page look weird.
