### PR TITLE
Add note about using iOS Frameworks for iOS add-to-app

### DIFF
--- a/src/content/docs/code-push/guides/hybrid-apps/ios.mdx
+++ b/src/content/docs/code-push/guides/hybrid-apps/ios.mdx
@@ -29,17 +29,15 @@ not created a Shorebird account, please see our
 The reference code for this guide is available at
 https://github.com/shorebirdtech/samples/tree/main/add_to_app.
 
-
 :::note
 
 Shorebird only supports the iOS Framework embedding method of adding Flutter to
-a native iOS app (see "Use iOS frameworks" in the [official integration
-docs](https://docs.flutter.dev/add-to-app/ios/project-setup)). We have an open
-issue to support embedding via CocoaPods
+a native iOS app (see "Use iOS frameworks" in the
+[official integration docs](https://docs.flutter.dev/add-to-app/ios/project-setup)).
+We have an open issue to support embedding via CocoaPods
 ([link](https://github.com/shorebirdtech/shorebird/issues/1198)), but given that
-[Flutter plans to deprecate CocoaPods
-support](https://github.com/flutter/flutter/issues/168015), it is unlikely that
-this will be implemented.
+[Flutter plans to deprecate CocoaPods support](https://github.com/flutter/flutter/issues/168015),
+it is unlikely that this will be implemented.
 
 :::
 

--- a/src/content/docs/code-push/guides/hybrid-apps/ios.mdx
+++ b/src/content/docs/code-push/guides/hybrid-apps/ios.mdx
@@ -29,6 +29,20 @@ not created a Shorebird account, please see our
 The reference code for this guide is available at
 https://github.com/shorebirdtech/samples/tree/main/add_to_app.
 
+
+:::note
+
+Shorebird only supports the iOS Framework embedding method of adding Flutter to
+a native iOS app (see "Use iOS frameworks" in the [official integration
+docs](https://docs.flutter.dev/add-to-app/ios/project-setup)). We have an open
+issue to support embedding via Cocoapods
+([link](https://github.com/shorebirdtech/shorebird/issues/1198)), but given that
+[Flutter plans to deprecate Cocoapods
+support](https://github.com/flutter/flutter/issues/168015), it is unlikely that
+this will be implemented.
+
+:::
+
 ## Add Shorebird to your Flutter module
 
 First, run `shorebird init` in your Flutter module:

--- a/src/content/docs/code-push/guides/hybrid-apps/ios.mdx
+++ b/src/content/docs/code-push/guides/hybrid-apps/ios.mdx
@@ -35,9 +35,9 @@ https://github.com/shorebirdtech/samples/tree/main/add_to_app.
 Shorebird only supports the iOS Framework embedding method of adding Flutter to
 a native iOS app (see "Use iOS frameworks" in the [official integration
 docs](https://docs.flutter.dev/add-to-app/ios/project-setup)). We have an open
-issue to support embedding via Cocoapods
+issue to support embedding via CocoaPods
 ([link](https://github.com/shorebirdtech/shorebird/issues/1198)), but given that
-[Flutter plans to deprecate Cocoapods
+[Flutter plans to deprecate CocoaPods
 support](https://github.com/flutter/flutter/issues/168015), it is unlikely that
 this will be implemented.
 


### PR DESCRIPTION
Our docs were not especially clear that this is the only method of add-to-app that we support.