### PR TITLE
Make patch signing less beta-y

### DIFF
--- a/src/content/docs/code-push/guides/patch-signing.mdx
+++ b/src/content/docs/code-push/guides/patch-signing.mdx
@@ -65,6 +65,14 @@ stored securely and kept secret. While the private key is not itself sufficient
 to make an update to your application (someone would also need access to your
 Shorebird credentials), it should not be checked into public source control.
 
+:::note
+
+We do not yet manage signing keys for you or support non-RSA keys. Please
+contact us if you have other requirements—we'd be happy to work with you to
+support your needs.
+
+:::
+
 ### Create a release containing the public key
 
 To create a release that requires signed patches, run the following command:


### PR DESCRIPTION
Removes negative language about readiness of patch signing, encourages companies to reach out if the current solution doesn't meet their needs.