### PR TITLE
fix: update note about patch signing

### DIFF
--- a/src/content/docs/code-push/system-architecture.mdx
+++ b/src/content/docs/code-push/system-architecture.mdx
@@ -144,7 +144,7 @@ The hash is not meant to be a security feature, but rather a way to detect
 errors in the patch diff. A common error we see is that developers
 `shorebird release` with one source and then actually build and release a
 different binary, resulting then in invalid patches. This hash helps detect such
-errors. For added security we also provide a way for you to
+errors. For added security, we also provide a way for you to
 [sign your patches](/code-push/guides/patch-signing/) if needed per your
 security requirements.
 


### PR DESCRIPTION
## Status

**READY**

## Description

Remove a note about us not supporting patch signing and instead point readers to our patch signing page if needed.