### PR TITLE
docs: update our minimum supported flutter version on Android

### DIFF
--- a/src/content/docs/getting-started/flutter-version.mdx
+++ b/src/content/docs/getting-started/flutter-version.mdx
@@ -69,8 +69,8 @@ upgrading or deploying.
 
 - November 17, 2025: Removed support for Android versions older then 3.24.0.
   While technically Shorebird could still run on those older versions, there are
-  known issues before 3.24.0 and we are now recommending all users upgrade to
-  at least 3.24.0 (August 6, 2024).
+  known issues before 3.24.0 and we are now recommending all users upgrade to at
+  least 3.24.0 (August 6, 2024).
 - September 23, 2025: We found and
   [fixed an issue](https://github.com/shorebirdtech/shorebird/pull/3327) with a
   version mismatch between Flutter & Dart. This affects Flutter 3.35.3. If you


### PR DESCRIPTION
We've not yet updated the `shorebird` code to enforce this, but consider this PR permission to do so at next opportunity.