### PR TITLE
docs: explain how to pass --force to the install script

### DIFF
--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -47,6 +47,15 @@ iwr -UseBasicParsing 'https://raw.githubusercontent.com/shorebirdtech/install/ma
 
 </CodeTabs>
 
+:::tip
+If you already have Shorebird installed and want to overwrite the existing installation, pass `--force` to the install script:
+
+```bash
+curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash -s -- --force
+```
+
+:::
+
 :::note
 
 Installing Shorebird CLI requires `git`.

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -47,8 +47,8 @@ iwr -UseBasicParsing 'https://raw.githubusercontent.com/shorebirdtech/install/ma
 
 </CodeTabs>
 
-:::tip
-If you already have Shorebird installed and want to overwrite the existing installation, pass `--force` to the install script:
+:::tip If you already have Shorebird installed and want to overwrite the
+existing installation, pass `--force` to the install script:
 
 ```bash
 curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | bash -s -- --force


### PR DESCRIPTION
## Summary
- Adds a tip after the install command showing how to pass `--force` to overwrite an existing Shorebird installation
- The correct syntax is `| bash -s -- --force` (not `| bash --force`, which passes `--force` to bash itself)

Closes #423

## Test plan
- [ ] Verify the tip renders correctly on the docs site