### PR TITLE
docs: clarify that applicationIdSuffix is optional in Android flavors guide

### DIFF
--- a/src/content/docs/code-push/guides/flavors/android.mdx
+++ b/src/content/docs/code-push/guides/flavors/android.mdx
@@ -94,6 +94,14 @@ buildTypes {
 </TabItem>
 </Tabs>
 
+:::caution
+
+The `applicationIdSuffix` property is optional. If you use services that depend
+on a consistent package name (e.g., Firebase), removing `applicationIdSuffix`
+may be necessary to avoid configuration issues.
+
+:::
+
 Lastly, edit `android/app/src/main/AndroidManifest.xml` to use the
 `applicationLabel` so that we can differentiate the two apps easily:
 


### PR DESCRIPTION
## Summary
- Adds a caution admonition after the flavor configuration code blocks in the Android flavors guide, noting that `applicationIdSuffix` is optional and may cause issues with services like Firebase that depend on consistent package names.

Closes #156

## Test plan
- [ ] Verify the caution admonition renders correctly on the docs site
- [ ] Confirm it appears between the flavor config tabs and the AndroidManifest section