### PR TITLE
docs: add FAQ about iOS Simulator not being supported

### DIFF
--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -294,6 +294,17 @@ the latest version from the server if needed.
 If you have a use case for code push with Fluter web, we'd
 [love to know](mailto:contact@shorebird.dev)!
 
+### Does Shorebird work on the iOS Simulator?
+
+No. Shorebird's code push does not work on the iOS Simulator. On physical iOS
+devices, Shorebird uses a custom ARM interpreter to run patched Dart code. The
+iOS Simulator runs on your Mac's native architecture (x86_64 or Apple Silicon),
+which is fundamentally different from the ARM environment on real iOS devices.
+Because the patching mechanism is built specifically for the iOS device runtime,
+it cannot function in the simulator.
+
+To test patches on iOS, you will need to use a physical iOS device.
+
 ## Technical Details
 
 ### What does the Shorebird updater store on disk?

--- a/src/content/docs/code-push/guides/flavors/android.mdx
+++ b/src/content/docs/code-push/guides/flavors/android.mdx
@@ -94,6 +94,14 @@ buildTypes {
 </TabItem>
 </Tabs>
 
+:::caution
+
+The `applicationIdSuffix` property is optional. If you use services that depend
+on a consistent package name (e.g., Firebase), removing `applicationIdSuffix`
+may be necessary to avoid configuration issues.
+
+:::
+
 Lastly, edit `android/app/src/main/AndroidManifest.xml` to use the
 `applicationLabel` so that we can differentiate the two apps easily:
 


### PR DESCRIPTION
## Summary
- Adds a new FAQ entry explaining that Shorebird code push does not work on the iOS Simulator
- Explains the technical reason: the patching mechanism relies on an ARM interpreter for physical iOS devices, which is incompatible with the simulator's architecture

Closes #171

## Test plan
- [ ] Verify the FAQ renders correctly on the docs site