### PR TITLE
chore: spell-check all file types, not just md/mdx

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -11,7 +11,12 @@ dictionaryDefinitions:
     path: https://raw.githubusercontent.com/verygoodopensource/very_good_dictionaries/main/forbidden.txt
     description: Forbidden spellings
 useGitignore: false
-ignorePaths: [dist, node_modules, package-lock.json, plugins]
+ignorePaths:
+  - dist
+  - node_modules
+  - package-lock.json
+  - plugins
+  - '**/*.svg'
 words:
   - aarch
   - aars
@@ -38,11 +43,13 @@ words:
   - jank
   - janky
   - keyrings
+  - lavamoat
   - libapp
   - libflutter
   - libglu
   - libstdc
   - libupdater
+  - llms
   - localappdata
   - logcat
   - longpaths
@@ -52,7 +59,10 @@ words:
   - mipmap
   - mozallowfullscreen
   - nubank
+  - opengraph
   - outform
+  - paweł
+  - pixelmator
   - podfile
   - prefs
   - pubin
@@ -68,6 +78,7 @@ words:
   - shorebirdtech
   - softwareupdate
   - subosito
+  - tabler
   - temurin
   - uiscene
   - webkitallowfullscreen

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,4 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1
     with:
       config: .cspell.yaml
-      includes: |
-        **/*.md
-        **/*.mdx
       modified_files_only: false

--- a/src/components/starlight/Head.astro
+++ b/src/components/starlight/Head.astro
@@ -17,4 +17,5 @@ const ogImageUrl = getImagePath({ url: Astro.url, site: Astro.site });
   src="https://plausible.io/js/script.tagged-events.js"></script>
 
 <!-- Unify Website Tag -->
+<!-- cspell:disable-next-line -->
 <script is:inline>!function(){var e=["identify","page","startAutoPage","stopAutoPage","startAutoIdentify","stopAutoIdentify"];function t(o){return Object.assign([],e.reduce(function(r,n){return r[n]=function(){return o.push([n,[].slice.call(arguments)]),o},r},{}))}window.unify||(window.unify=t(window.unify)),window.unifyBrowser||(window.unifyBrowser=t(window.unifyBrowser));var n=document.createElement("script");n.async=!0,n.setAttribute("src","https://tag.unifyintent.com/v1/QoBw2RtKMRTC8SgiRGVoqm/script.js"),n.setAttribute("data-api-key","wk_aZd1Wuvn_66qeweFDZsr2swVJShPAMpqiwuEv4VHm"),n.setAttribute("id","unifytag"),(document.body||document.head).appendChild(n)}();</script>


### PR DESCRIPTION
## Summary

- Drop the `includes:` narrowing from the `spell-check` workflow so cspell scans all recognized files (`.astro`, `.tsx`, `.mjs`, `package.json`, etc.), matching how other Shorebird repos run cspell.
- Make the existing set of files pass cleanly:
  - Add `lavamoat`, `llms`, `opengraph`, `paweł`, `pixelmator`, `tabler` to `words:`.
  - Add `**/*.svg` to `ignorePaths:` — flagged words there are editor-signature metadata (`Pixelmator`, `Paweł`) that churns on every re-export, not authored prose.
  - `cspell:disable-next-line` the Unify analytics blob in `Head.astro`; its tracking-key fragments (`Wuvn`, `qewe`, `Mpqiwu`, `unifytag`) aren't dictionary-worthy words.

## Why

The md/mdx-only scope lived in the workflow's `includes:` input, so anything invoking cspell *without* that input (local CLI, editor extensions, Shorebird CI) would scan every file type cspell recognizes and flag 23 pre-existing issues in 9 files. Rather than hide those issues behind a CI-only glob, fix them and let cspell catch typos in non-doc files too.

## Verification

```
$ npx cspell --config .cspell.yaml "**/*" --no-progress
CSpell: Files checked: 82, Issues found: 0 in 0 files.
```

`npm run format:check` passes.

## Test plan

- [ ] CI `build` is green.
- [ ] CI `spell-check / build` is green (now scanning everything).