### PR TITLE
chore: update Flutter to 3.41.7 and Dart to 3.11.5

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.41.6',
-  dart: '3.11.4',
-  flutter_release_date: 'March 2026',
+  flutter: '3.41.7',
+  dart: '3.11.5',
+  flutter_release_date: 'April 2026',
 };


### PR DESCRIPTION
## Summary
- Update Flutter version from 3.41.6 to 3.41.7
- Update Dart version from 3.11.4 to 3.11.5
- Update release date to April 2026

## Test plan
- [ ] Verify version numbers render correctly in the built docs