### PR TITLE
faq: replace stale engine-size claim with real numbers

### DIFF
--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -331,10 +331,28 @@ your system should you choose.
 
 ### How big of a dependency footprint does this add?
 
-We expect the code push library to add less than one megabyte to Flutter apps.
-`flutter build apk --release` vs. `shorebird build apk --release` should give
-you a rough idea but keep in mind that many store distributions do also
-automatically thin your app for the device that it is being installed on.
+Shorebird ships its own build of the Flutter engine with the patching runtime
+included, which is where the overhead comes from. The table below compares
+Shorebird's engine against stock Flutter for the same engine version, measured
+on the stripped binaries that actually ship to users:
+
+| Platform            | Shorebird (on-disk / download) | Flutter (on-disk / download) | Shorebird overhead  |
+| ------------------- | ------------------------------ | ---------------------------- | ------------------- |
+| iOS (arm64)         | 13.25 MB / 5.68 MB             | 8.58 MB / 3.67 MB            | +4.67 MB / +2.01 MB |
+| Android (arm64-v8a) | 13.38 MB / 6.40 MB             | 10.79 MB / 5.06 MB           | +2.58 MB / +1.35 MB |
+
+"On-disk" is the uncompressed size installed on the device. "Download" is the
+approximate size shipped over the store — APKs and IPAs use DEFLATE compression,
+which `gzip -9` closely mimics, so the gzipped size is a good proxy for what a
+user's device actually pulls down.
+
+These numbers are for Flutter 3.41.7 (April 2026). Earlier Shorebird engines
+were meaningfully larger — iOS overhead alone came down by roughly 2 MB on-disk
+in the preceding month — and we continue to shrink the overhead as we optimize.
+You can reproduce a rough measurement on your own app by comparing the output of
+`flutter build apk --release` against `shorebird build apk --release`. Keep in
+mind that app stores thin distributions for the installing device, so the real
+number a given user downloads may be smaller.
 
 ### When do updates happen?
 

--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -350,9 +350,7 @@ These numbers are for Flutter 3.41.7 (April 2026). Earlier Shorebird engines
 were meaningfully larger — iOS overhead alone came down by roughly 2 MB on-disk
 in the preceding month — and we continue to shrink the overhead as we optimize.
 You can reproduce a rough measurement on your own app by comparing the output of
-`flutter build apk --release` against `shorebird build apk --release`. Keep in
-mind that app stores thin distributions for the installing device, so the real
-number a given user downloads may be smaller.
+`flutter build apk --release` against `shorebird build apk --release`.
 
 ### When do updates happen?
 

--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -348,8 +348,10 @@ user's device actually pulls down.
 
 These numbers are for Flutter 3.41.7 (April 2026). Earlier Shorebird engines
 were meaningfully larger — iOS overhead alone came down by roughly 2 MB on-disk
-in the preceding month — and we continue to shrink the overhead as we optimize.
-You can reproduce a rough measurement on your own app by comparing the output of
+in the preceding month — and we continue to shrink the overhead; progress is
+tracked in
+[shorebird#3715](https://github.com/shorebirdtech/shorebird/issues/3715). You
+can reproduce a rough measurement on your own app by comparing the output of
 `flutter build apk --release` against `shorebird build apk --release`.
 
 ### When do updates happen?


### PR DESCRIPTION
## Summary

- Closes #19.
- Replaces the "less than one megabyte" claim in the code-push FAQ with a concrete table of stripped engine sizes (on-disk and download, iOS arm64 and Android arm64-v8a) for Shorebird vs. stock Flutter on the current Flutter 3.41.7 engine.
- Notes that earlier Shorebird engines were larger, without dwelling on specific historical numbers, so the answer ages reasonably as we continue to shrink the overhead.

## Numbers

Measured via the `compare_sizes` tool, with `gzip -9` as a proxy for the DEFLATE compression used by APK/IPA:

| Platform            | Shorebird (on-disk / download) | Flutter (on-disk / download) | Overhead            |
| ------------------- | ------------------------------ | ---------------------------- | ------------------- |
| iOS (arm64)         | 13.25 MB / 5.68 MB             | 8.58 MB / 3.67 MB            | +4.67 MB / +2.01 MB |
| Android (arm64-v8a) | 13.38 MB / 6.40 MB             | 10.79 MB / 5.06 MB           | +2.58 MB / +1.35 MB |

Shorebird engine `21934c19…` / Flutter engine `59aa584f…` (both Flutter 3.41.7, April 2026).

Month-over-month sanity check against the 3.41.5-rc0 Shorebird engine (`87bc2083…`, 2026-03-25): iOS dropped from 15.29 MB to 13.25 MB on-disk (~2 MB), Android stripped dropped from 14.59 MB to 13.38 MB (~1.2 MB). That's the basis for the "iOS overhead came down by roughly 2 MB in the preceding month" line.

## Test plan

- [ ] `npm run build` (astro check + build) passes locally
- [ ] `faq.mdx` renders with the table formatted correctly on the live preview