### PR TITLE
chore: update Flutter to 3.41.8

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.41.7',
+  flutter: '3.41.8',
   dart: '3.11.5',
   flutter_release_date: 'April 2026',
 };


### PR DESCRIPTION
## Summary
- Update Flutter version from 3.41.7 to 3.41.8
- Dart version unchanged (still 3.11.5)

## Test plan
- [ ] Verify version numbers render correctly in the built docs