### PR TITLE
ci: add triage automation workflow

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,21 @@
+name: Triage automation
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add needs-triage label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api -X POST "repos/$REPO/issues/$NUMBER/labels" \
+            -f 'labels[]=needs-triage'


### PR DESCRIPTION
## Summary

Adds `.github/workflows/triage.yaml` to power the new weekly triage process.

PR-only flavor — only PRs are added to the queue (issues here aren't part of the meeting). On `pull_request_target.opened` it applies the `needs-triage` label so new PRs land in the org-level [Triage project](https://github.com/orgs/shorebirdtech/projects/25).

`pull_request_target` is used (not `pull_request`) so labeling works on PRs from forks. The workflow does **not** check out PR code, so it's safe.

## Context

One of five PRs rolling out the new triage workflow across `shorebird`, `_shorebird`, `dart-sdk`, `flutter`, and `docs`. The label `needs-triage` was just created in this repo.

## Test plan

- [ ] Merge → open a test PR → confirm `needs-triage` is auto-applied