### PR TITLE
Bump Flutter 3.41.9 → 3.44.0, Dart 3.11.5 → 3.12.0

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.41.9',
-  dart: '3.11.5',
-  flutter_release_date: 'April 2026',
+  flutter: '3.44.0',
+  dart: '3.12.0',
+  flutter_release_date: 'May 2026',
 };


### PR DESCRIPTION
Reflects the Shorebird v1.6.101 release which ships Flutter 3.44.0 and Dart 3.12.0.

Released at https://github.com/shorebirdtech/shorebird/releases/tag/v1.6.101