### PR TITLE
docs(ci): add deprecation notice w/ Aug 8, 2026 shutoff date

### DIFF
--- a/src/content/docs/ci/checks/analyze.mdx
+++ b/src/content/docs/ci/checks/analyze.mdx
@@ -3,6 +3,15 @@ title: Analyze
 description: The details of the Analyze check in Shorebird CI
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 Shorebird CI's "Analyze" check uses
 [`dart analyze`](https://dart.dev/tools/dart-analyze) to perform static analysis
 across all of your Dart files.

--- a/src/content/docs/ci/checks/check-spelling.mdx
+++ b/src/content/docs/ci/checks/check-spelling.mdx
@@ -3,6 +3,15 @@ title: Check Spelling
 description: The details of the Check Spelling check in Shorebird CI
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 Shorebird CI's "Check Spelling" check uses [CSpell](https://cspell.org) to look
 for misspelled words in your code base.
 

--- a/src/content/docs/ci/checks/format.mdx
+++ b/src/content/docs/ci/checks/format.mdx
@@ -3,6 +3,15 @@ title: Format
 description: The details of the Format check in Shorebird CI
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 Shorebird CI's "Format" check uses
 [`dart format`](https://dart.dev/tools/dart-format) to look for consistent
 formatting across all of your Dart files.

--- a/src/content/docs/ci/checks/index.mdx
+++ b/src/content/docs/ci/checks/index.mdx
@@ -3,6 +3,15 @@ title: Overview
 description: The landing page for the Checks detail section
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 Shorebird CI contains a number of checks built into the system. With each run
 all of our checks are automatically ran with no need for setup from you or your
 team.

--- a/src/content/docs/ci/checks/run-tests.mdx
+++ b/src/content/docs/ci/checks/run-tests.mdx
@@ -3,6 +3,15 @@ title: Run Tests
 description: The details of the Run Tests check in Shorebird CI
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 Shorebird CI's "Run Test" check will run any test files that are found to ensure
 they are passing.
 

--- a/src/content/docs/ci/checks/upload-coverage.mdx
+++ b/src/content/docs/ci/checks/upload-coverage.mdx
@@ -3,6 +3,15 @@ title: Upload Coverage
 description: The details of the Upload Coverage check in Shorebird CI
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 Shorebird CI's "Upload Coverage" check will upload your coverage report to
 [Codecov](https://about.codecov.io) in order to see a comprehensive history of
 your coverage for your code base.

--- a/src/content/docs/ci/faq.mdx
+++ b/src/content/docs/ci/faq.mdx
@@ -5,6 +5,15 @@ sidebar:
   order: 5
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 Still have a question about Shorebird CI that our docs didn’t cover? You’re in
 the right place. This page covers the most common questions. If you have a
 question not answered here or elsewhere in the docs, reach out on Discord or

--- a/src/content/docs/ci/index.mdx
+++ b/src/content/docs/ci/index.mdx
@@ -6,12 +6,12 @@ sidebar:
   order: 1
 ---
 
-:::note
+:::caution[Shorebird CI is being deprecated]
 
-Shorebird CI is currently in beta. You can expect some rough edges at this time.
-If you have questions please join the
-[CI channel](https://discord.com/channels/1030243211995791380/1395167987211833456)
-in our [Discord Server](https://discord.gg/shorebird) for help.
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
 
 :::
 

--- a/src/content/docs/ci/setup.mdx
+++ b/src/content/docs/ci/setup.mdx
@@ -6,6 +6,15 @@ sidebar:
   order: 2
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 import { Image } from 'astro:assets';
 import ciConsoleNavigation from '~/assets/ci_console_navigation.png';
 import ciLoginWithGitHub from '~/assets/ci_login_with_github_screen.png';

--- a/src/content/docs/ci/uninstall.mdx
+++ b/src/content/docs/ci/uninstall.mdx
@@ -5,6 +5,15 @@ sidebar:
   order: 4
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 import { Image } from 'astro:assets';
 import ciListInstalledGHApps from '~/assets/ci_list_installed_gh_apps.png';
 import ciGHAppSettings from '~/assets/ci_gh_app_settings.png';

--- a/src/content/docs/ci/view-logs.mdx
+++ b/src/content/docs/ci/view-logs.mdx
@@ -5,6 +5,15 @@ sidebar:
   order: 3
 ---
 
+:::caution[Shorebird CI is being deprecated]
+
+Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
+Existing customers continue to run until the shutoff date. See the
+[Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
+for migration options.
+
+:::
+
 import { Image } from 'astro:assets';
 import ciViewRunDetails from '~/assets/ci_view_run_details.png';
 import ciWebConsoleLogs from '~/assets/ci_web_console_logs.png';


### PR DESCRIPTION
## Summary

Shorebird CI is being shut down on August 8, 2026 and new sign-ups are already closed in the dashboard. Adding the same notice to every public CI doc page so anyone evaluating the product reads the deprecation before they read the setup steps.

Replaces the "currently in beta" note on the overview page since the product is past that question.

## Testing

- `npm run build` clean, 59 pages built, all internal links valid
- Previewed every CI page locally and confirmed the callout renders