### PR TITLE
chore: bump Flutter to 3.44.1 / Dart to 3.12.1

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.0',
-  dart: '3.12.0',
-  flutter_release_date: 'May 2026',
+  flutter: '3.44.1',
+  dart: '3.12.1',
+  flutter_release_date: 'June 2026',
 };


### PR DESCRIPTION
Updates the documented Flutter and Dart versions for the Shorebird 3.44.1 release (shorebird_cli 1.6.106).

- Flutter 3.44.0 → 3.44.1
- Dart 3.12.0 → 3.12.1
- Release date → June 2026

Follows the pattern of https://github.com/shorebirdtech/docs/pull/521.