### PR TITLE
fix: add rermak parser back in to fix tables

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,7 @@ import { readFileSync } from 'node:fs';
 import starlightLlmsTxt from 'starlight-llms-txt';
 import { remarkReplaceVersions } from './src/plugins/replace-versions.ts';
 import mermaid from 'astro-mermaid';
+import remarkGfm from 'remark-gfm';
 
 const site = 'https://docs.shorebird.dev/';
 
@@ -20,7 +21,7 @@ const site = 'https://docs.shorebird.dev/';
 export default defineConfig({
   site,
   markdown: {
-    remarkPlugins: [remarkReplaceVersions],
+    remarkPlugins: [remarkReplaceVersions, remarkGfm],
   },
   vite: {
     plugins: [tailwindcss()],


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Starlight calls `mdx({ optimize: true })` with no `gfm` option, and Astro v6 removed the `gfm: true` default from the markdown config schema. So the MDX integration's `if (mdxOptions.gfm)` check was always false, and remark-gfm was never added to the MDX pipeline.

The fix explicitly adds remarkGfm to markdown.remarkPlugins, which markdownConfigToMdxOptions passes directly into the MDX pipeline bypassing the broken gfm flag entirely.
