### PR TITLE
chore: bump Flutter to 3.44.2 / Dart to 3.12.2

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.1',
-  dart: '3.12.1',
+  flutter: '3.44.2',
+  dart: '3.12.2',
   flutter_release_date: 'June 2026',
 };


### PR DESCRIPTION
Updates the documented Flutter/Dart versions for the Shorebird 1.6.108 release (Flutter 3.44.2 / Dart 3.12.2).

Follows the prior bump PR (#549, 3.44.1).