### PR TITLE
chore: bump Flutter to 3.44.4

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.3',
+  flutter: '3.44.4',
   dart: '3.12.2',
   flutter_release_date: 'June 2026',
 };


### PR DESCRIPTION
Bumps the documented Flutter version to 3.44.4 (Dart stays 3.12.2) for the Shorebird 1.6.110 release.