### PR TITLE
fix: Fix spelling error in hot reload mechanics section

### DIFF
--- a/src/content/docs/flutter-concepts/flutter-sdk-deep-dive.mdx
+++ b/src/content/docs/flutter-concepts/flutter-sdk-deep-dive.mdx
@@ -174,7 +174,7 @@ increased complexity.
 
 ## Hot reload mechanics depend on Dart VM code injection
 
-One of the first things that Flutter was noticed for was Hot Reload. Fluter’s
+One of the first things that Flutter was noticed for was Hot Reload. Flutter’s
 hot-reload provides you with sub-second, on-device updates to your running app
 while you’re editing your code. Pulling that off is no small feat.
 


### PR DESCRIPTION
Corrected the spelling of 'Fluter' to 'Flutter' in the hot reload section.

<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Fix mispelling
