### PR TITLE
docs: fix Code Push casing and Fluter typo regression in FAQ

### DIFF
--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -396,7 +396,7 @@ code and do not require a JIT Dart compiler.
 Code Push isn't needed for Flutter web. When a user opens a web app it downloads
 the latest version from the server if needed.
 
-If you have a use case for code push with Fluter web, we'd
+If you have a use case for Code Push with Flutter web, we'd
 [love to know](mailto:contact@shorebird.dev).
 
 ## Technical Details


### PR DESCRIPTION
## Status

**READY**

## Description

A small but real regression on `main` right now: [#581](https://github.com/shorebirdtech/docs/pull/581) (a typo fix, "Fluter" → "Flutter") was branched from content that predated [#579](https://github.com/shorebirdtech/docs/pull/579) (proper-noun capitalization). Both PRs touched the same line in `faq.mdx`. By the time both merged, the line had reverted to the pre-#579 casing ("code push" lowercase) *and* the pre-#581 typo ("Fluter") — invisible in either PR's own diff, since it happened via merge ordering, not either PR's actual changes.

Found this while checking whether the content-guideline lint checks could be made blocking — it would have silently broken that effort, since `Vale.Terms` (proper-noun capitalization) runs at `error` severity and this line's lowercase "code push" would show up as an unexplained new failure with no obvious cause in the diff.

## Test plan

- [x] `npm run build` succeeds