### PR TITLE
chore: bump Flutter to 3.44.5

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
   flutter: '3.44.5',
   dart: '3.12.2',
-  flutter_release_date: 'June 2026',
+  flutter_release_date: 'July 2026',
 };

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.4',
+  flutter: '3.44.5',
   dart: '3.12.2',
   flutter_release_date: 'June 2026',
 };


### PR DESCRIPTION
Bump the documented Flutter version to 3.44.5 for the shorebird_cli 1.6.111 release. Dart stays at 3.12.2.