### PR TITLE
chore: bump Flutter to 3.44.6

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.5',
+  flutter: '3.44.6',
   dart: '3.12.2',
   flutter_release_date: 'July 2026',
 };


### PR DESCRIPTION
Bumps the documented Flutter version to 3.44.6 for the Shorebird 1.6.112 release. Dart stays at 3.12.2 (unchanged between 3.44.5 and 3.44.6).