### PR TITLE
chore: update Flutter to 3.44.8

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.7',
+  flutter: '3.44.8',
   dart: '3.12.2',
   flutter_release_date: 'July 2026',
 };


### PR DESCRIPTION
## Summary

- Bump the documented Flutter version to 3.44.8, shipped in shorebird_cli 1.6.115.
- Dart stays at 3.12.2. The 3.44.7 -> 3.44.8 bump carries no Dart base change, so `dart_revision` is untouched.

## Testing

- Only `src/consts.ts` changed, single version string.