### PR TITLE
docs: Standardize and reposition Arcade video embeds

### DIFF
--- a/src/content/docs/account/api-keys.mdx
+++ b/src/content/docs/account/api-keys.mdx
@@ -13,6 +13,11 @@ environments. You can create, view, and revoke API keys from the
 
 ## Creating an API key
 
+<ArcadeEmbed
+  src="https://demo.arcade.software/TQUMnX2QwuCRzEV1e8kN?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+  title="Create Shorebird API Key"
+/>
+
 1. Open **Account → API Keys** in the console.
 2. Click **Create API Key**.
 3. Enter a descriptive name (e.g., "GitHub Actions — my-app").
@@ -22,11 +27,6 @@ environments. You can create, view, and revoke API keys from the
 
 The full key value is shown exactly once after creation. Copy it and store it
 securely — it cannot be retrieved again.
-
-<ArcadeEmbed
-  src="https://demo.arcade.software/TQUMnX2QwuCRzEV1e8kN?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
-  title="Create Shorebird API Key"
-/>
 
 ## Using an API key
 

--- a/src/content/docs/code-push/ci/_authentication.mdx
+++ b/src/content/docs/code-push/ci/_authentication.mdx
@@ -4,16 +4,16 @@ Most Shorebird functionality, like creating releases and patches, requires
 authentication. To authenticate in your CI, create an API key from the
 [Shorebird Console](https://console.shorebird.dev):
 
+<ArcadeEmbed
+  src="https://demo.arcade.software/TQUMnX2QwuCRzEV1e8kN?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+  title="Create Shorebird API Key"
+/>
+
 1. Go to **Account → API Keys**.
 2. Click **Create API Key**.
 3. Give the key a name (e.g., "GitHub Actions — my-app"), choose an expiration,
    and select a permission level.
 4. Copy the key value — it is only shown once.
-
-<ArcadeEmbed
-  src="https://demo.arcade.software/TQUMnX2QwuCRzEV1e8kN?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
-  title="Create Shorebird API Key"
-/>
 
 Use this key as your `SHOREBIRD_TOKEN` in CI. The environment variable name is
 unchanged from previous versions.

--- a/src/content/docs/code-push/create.mdx
+++ b/src/content/docs/code-push/create.mdx
@@ -6,6 +6,8 @@ sidebar:
   order: 2
 ---
 
+import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
+
 :::note
 
 If you have an existing project, you can use
@@ -18,6 +20,11 @@ To create a new Flutter project with Shorebird, use `shorebird create`:
 ```sh
 shorebird create my_app
 ```
+
+<ArcadeEmbed
+  src="https://app.arcade.software/share/eTUuhVp2OJkmg4vRGnRD"
+  title="Create a new Shorebird Project"
+/>
 
 This does several things:
 

--- a/src/content/docs/code-push/create.mdx
+++ b/src/content/docs/code-push/create.mdx
@@ -23,7 +23,7 @@ shorebird create my_app
 
 <ArcadeEmbed
   src="https://app.arcade.software/share/eTUuhVp2OJkmg4vRGnRD"
-  title="Create a new Shorebird Project"
+  title="Create a new flutter project with Shorebird"
 />
 
 This does several things:

--- a/src/content/docs/code-push/index.mdx
+++ b/src/content/docs/code-push/index.mdx
@@ -8,6 +8,13 @@ sidebar:
 
 import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
 
+For a quick overview, check out the demo below.
+
+<ArcadeEmbed
+  src="https://demo.arcade.software/x5ifkvJ8yFZh63hYJF0g?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+  title="Send over the air updates to Flutter app"
+/>
+
 ## What is Code Push?
 
 Code Push is a tool that allows you to update your Flutter app instantly over
@@ -57,13 +64,6 @@ A typical Code Push workflow looks like this:
    the first step.
 1. That's it. Your users will see the update the next time they restart your
    app.
-
-For a quick overview, check out the demo below.
-
-<ArcadeEmbed
-  src="https://demo.arcade.software/x5ifkvJ8yFZh63hYJF0g?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
-  title="Send over the air updates to Flutter app"
-/>
 
 ### Platform feature support matrix
 

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -12,7 +12,21 @@ import {
 } from 'starlight-theme-nova/components';
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
-{/* TODO: Add 2-minute installation walkthrough video */}
+{/* ARCADE EMBED START */}
+<div
+  style={{ position: 'relative', paddingBottom: 'calc(64.9471% + 41px)', height: '0px', width: '100%' }}
+>
+  <iframe
+    src="https://demo.arcade.software/ubNeLVcVK0dWIoM33oPg?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
+    title="Getting Started with Shorebird"
+    frameBorder="0"
+    loading="lazy"
+    allowFullScreen
+    allow="clipboard-write"
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', colorScheme: 'light' }}
+  ></iframe>
+</div>
+{/* ARCADE EMBED END */}
 
 This guide walks you through installing Shorebird and integrating it into your
 Flutter app.

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -13,13 +13,10 @@ import {
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
 
-{/* ARCADE EMBED START */}
-
 <ArcadeEmbed
   src="https://app.arcade.software/share/FP0avaIIQ1MtBzMaQpkT"
   title="Getting Started with Shorebird"
 />
-{/* ARCADE EMBED END */}
 
 This guide walks you through installing Shorebird and integrating it into your
 Flutter app.

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -13,8 +13,14 @@ import {
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 {/* ARCADE EMBED START */}
+
 <div
-  style={{ position: 'relative', paddingBottom: 'calc(64.9471% + 41px)', height: '0px', width: '100%' }}
+  style={{
+    position: 'relative',
+    paddingBottom: 'calc(64.9471% + 41px)',
+    height: '0px',
+    width: '100%',
+  }}
 >
   <iframe
     src="https://demo.arcade.software/ubNeLVcVK0dWIoM33oPg?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
@@ -23,7 +29,14 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
     loading="lazy"
     allowFullScreen
     allow="clipboard-write"
-    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', colorScheme: 'light' }}
+    style={{
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '100%',
+      height: '100%',
+      colorScheme: 'light',
+    }}
   ></iframe>
 </div>
 {/* ARCADE EMBED END */}

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -11,34 +11,13 @@ import {
   LinkCard,
 } from 'starlight-theme-nova/components';
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
 
 {/* ARCADE EMBED START */}
-
-<div
-  style={{
-    position: 'relative',
-    paddingBottom: 'calc(64.9471% + 41px)',
-    height: '0px',
-    width: '100%',
-  }}
->
-  <iframe
-    src="https://demo.arcade.software/ubNeLVcVK0dWIoM33oPg?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true"
-    title="Getting Started with Shorebird"
-    frameBorder="0"
-    loading="lazy"
-    allowFullScreen
-    allow="clipboard-write"
-    style={{
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: '100%',
-      height: '100%',
-      colorScheme: 'light',
-    }}
-  ></iframe>
-</div>
+<ArcadeEmbed
+  src="https://app.arcade.software/share/FP0avaIIQ1MtBzMaQpkT"
+  title="Getting Started with Shorebird"
+/>
 {/* ARCADE EMBED END */}
 
 This guide walks you through installing Shorebird and integrating it into your

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -14,6 +14,7 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
 
 {/* ARCADE EMBED START */}
+
 <ArcadeEmbed
   src="https://app.arcade.software/share/FP0avaIIQ1MtBzMaQpkT"
   title="Getting Started with Shorebird"


### PR DESCRIPTION
## What
- Refactored `getting-started/index.mdx` to use the `<ArcadeEmbed />` component instead of raw `<iframe>` HTML.
- Unified component imports to consistently use the `~` alias (`~/components/ArcadeEmbed.astro`).
- Added a new 10s Arcade walkthrough for `shorebird create my_app` to `code-push/create.mdx`.
- Repositioned several Arcade embeds to sit near the top of the page or their respective sections.

## Why
These changes implement a newly established documentation rule: *"When adding an Arcade embed to documentation, always place it near the top of the page or relevant section."* Shifting the embeds upwards ensures users get immediate visual context before diving into dense step-by-step instructions.

## Placements Updated
- **`account/api-keys.mdx`**: Moved the embed to sit directly below the `## Creating an API key` heading.
- **`code-push/index.mdx`**: Moved the overview embed to the very top of the page.
- **`code-push/ci/_authentication.mdx`**: Moved the API Key creation embed above the numbered steps.
