### PR TITLE
docs: Add Arcade walkthrough video to Quick Start page

### DIFF
--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -11,8 +11,12 @@ import {
   LinkCard,
 } from 'starlight-theme-nova/components';
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
 
-{/* TODO: Add 2-minute installation walkthrough video */}
+<ArcadeEmbed
+  src="https://app.arcade.software/share/rwhPDRat2tGYHouo8cO6"
+  title="Getting Started with Shorebird"
+/>
 
 This guide walks you through installing Shorebird and integrating it into your
 Flutter app.


### PR DESCRIPTION
## What
- Added the "Getting Started with Shorebird" Arcade video to `getting-started/index.mdx`.
- Removed the existing `TODO` placeholder.
- Utilized the existing `<ArcadeEmbed />` component with the standardized `~` import alias.

## Why
This provides users with a visual, interactive guide right at the start of their Shorebird journey. In accordance with our documentation guidelines, the video is positioned at the very top of the page so users can immediately get a high-level overview before diving into the step-by-step setup instructions.
