### PR TITLE
docs: add dedicated Tracks reference page

### DIFF
--- a/src/content/docs/code-push/guides/staging-patches.mdx
+++ b/src/content/docs/code-push/guides/staging-patches.mdx
@@ -13,6 +13,13 @@ import switchTrack from '~/assets/staging_patches_patch_context_menu.png';
 This guide will walk you through how to validate a patch in Shorebird's staging
 environment before promoting the patch to production.
 
+:::tip[New to tracks?]
+
+Tracks are named deployment channels that control which devices receive a patch.
+See the [Tracks](/code-push/tracks) reference page for a full explanation.
+
+:::
+
 ## Prerequisites
 
 This guide assumes the Shorebird command-line is installed on your machine and

--- a/src/content/docs/code-push/guides/testing-patches.mdx
+++ b/src/content/docs/code-push/guides/testing-patches.mdx
@@ -14,6 +14,12 @@ Shorebird’s mechanism to release to a subset of users is “tracks”. You can
 create an unlimited number of tracks with arbitrary names. If no track is
 specified, patches are distributed to the “stable” track by default.
 
+<LinkCard
+  href="/code-push/tracks"
+  title="What are Tracks?"
+  description="Learn how Shorebird tracks work, how to publish to them, and how to promote patches between tracks."
+/>
+
 Customers typically use "staging" for internal testing (on developers' machines)
 and "beta" for wider group testing (e.g. QA teams where `shorebird` commands are
 not available).

--- a/src/content/docs/code-push/index.mdx
+++ b/src/content/docs/code-push/index.mdx
@@ -177,6 +177,16 @@ For more information regarding when to create a patch, refer to the
 
 :::
 
+#### Track
+
+A track is a named deployment channel that controls which devices receive a
+patch. Every app has a built-in `stable` track (the default). Additional tracks
+such as `staging` or `beta` are created on demand by naming them when publishing
+a patch, and allow you to validate patches with a subset of devices before
+promoting them to all users.
+
+For a full explanation, see [Tracks](/code-push/tracks).
+
 #### Artifact
 
 An artifact is the output of a build or patch operation. For example:

--- a/src/content/docs/code-push/patch.mdx
+++ b/src/content/docs/code-push/patch.mdx
@@ -135,16 +135,16 @@ directly.
 
 ## Options
 
-| Option                 | Abbreviation | Description                                                                                                |
-| ---------------------- | ------------ | ---------------------------------------------------------------------------------------------------------- |
-| `--release-version`    |              | The release version to patch (e.g., `1.0.0+1`). Use `latest` to target the most recently updated release.  |
-| `--platforms`          | `-p`         | Comma-separated list of platforms to patch simultaneously (e.g., `android,ios`).                           |
-| `--flavor`             |              | The product flavor to use when building.                                                                   |
-| `--target`             | `-t`         | The main entrypoint file of the application.                                                               |
-| `--track`              |              | The deployment track to publish to (default: `stable`). Use `staging` to publish to a staging track first. |
-| `--dry-run`            | `-n`         | Build and validate the patch but **do not upload** it. Ideal as a CI sanity check.                         |
-| `--allow-asset-diffs`  |              | Publish even if asset differences are detected. **Not recommended.**                                       |
-| `--allow-native-diffs` |              | Publish even if native code differences are detected. **Not recommended.**                                 |
+| Option                 | Abbreviation | Description                                                                                                                                          |
+| ---------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--release-version`    |              | The release version to patch (e.g., `1.0.0+1`). Use `latest` to target the most recently updated release.                                            |
+| `--platforms`          | `-p`         | Comma-separated list of platforms to patch simultaneously (e.g., `android,ios`).                                                                     |
+| `--flavor`             |              | The product flavor to use when building.                                                                                                             |
+| `--target`             | `-t`         | The main entrypoint file of the application.                                                                                                         |
+| `--track`              |              | The deployment track to publish to (default: `stable`). Use `staging` to publish to a staging track first. See [Tracks](/code-push/tracks) for more. |
+| `--dry-run`            | `-n`         | Build and validate the patch but **do not upload** it. Ideal as a CI sanity check.                                                                   |
+| `--allow-asset-diffs`  |              | Publish even if asset differences are detected. **Not recommended.**                                                                                 |
+| `--allow-native-diffs` |              | Publish even if native code differences are detected. **Not recommended.**                                                                           |
 
 ### iOS-specific options
 

--- a/src/content/docs/code-push/tracks.mdx
+++ b/src/content/docs/code-push/tracks.mdx
@@ -97,6 +97,14 @@ applying the latest patch available on the specified track.
 Once you've validated a patch on a staging track, you can promote it to `stable`
 without rebuilding. This pushes the patch to all production users.
 
+:::note
+
+The Shorebird console and the `shorebird patches promote` command only promote a
+patch to `stable`. To move a patch to a different custom track, use
+`shorebird patches set-track` from the CLI.
+
+:::
+
 ### Via the Shorebird console
 
 Navigate to the release details page, click the **⋮** context menu next to the
@@ -112,13 +120,13 @@ shorebird patches promote \
   --patch-number 1
 ```
 
-Or assign a patch to any track by name:
+To move a patch to any other track by name, use `set-track`:
 
 ```bash
 shorebird patches set-track \
   --release-version 1.0.0+1 \
   --patch-number 1 \
-  --track stable
+  --track beta
 ```
 
 ## Subscribing a device to a track
@@ -220,3 +228,16 @@ request patches from the new track on its next update check.
 If no patch is available on the requested track for the current release version,
 the device continues to run the base release (or the last successfully applied
 patch). It does **not** fall back to the `stable` track automatically.
+
+### Can you promote a patch to a track other than stable?
+
+Not from the Shorebird console or `shorebird patches promote`. Those only target
+`stable`. However, you can use `shorebird patches set-track` from the CLI to
+assign a patch to any named track:
+
+```bash
+shorebird patches set-track \
+  --release-version 1.0.0+1 \
+  --patch-number 1 \
+  --track beta
+```

--- a/src/content/docs/code-push/tracks.mdx
+++ b/src/content/docs/code-push/tracks.mdx
@@ -1,0 +1,222 @@
+---
+title: Tracks
+description:
+  Use tracks to control which devices receive a patch, enabling staged rollouts
+  and internal testing workflows.
+sidebar:
+  order: 7
+---
+
+import { CodeTabs, LinkCard } from 'starlight-theme-nova/components';
+
+**Tracks** are named deployment channels that control which devices receive a
+patch. Every Shorebird app has a built-in `stable` track, which is the default
+channel that all devices subscribe to. You can create additional tracks (such as
+`staging` or `beta`) on the fly, simply by naming them when publishing a patch.
+No configuration or registration is needed; tracks are created implicitly.
+
+## How tracks work
+
+When your app starts up, the Shorebird updater asks the server: _"Is there a new
+patch on the **stable** track for this release version?"_ If you have integrated
+`package:shorebird_code_push`, your app can instead ask for patches on a
+different named track. This makes it possible to route specific devices (e.g.,
+your QA team's phones) to a `beta` or `staging` patch without affecting
+production users.
+
+```mermaid
+flowchart LR
+    A["patch --track=staging"] --> B{"Validate"}
+    B -- "Issues" --> A
+    B -- "OK" --> C["Promote to stable"]
+    C --> D["All devices update"]
+```
+
+## Built-in vs. custom tracks
+
+| Track      | Description                                                                                                 |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| `stable`   | The default track. All devices receive patches from this track unless they explicitly subscribe to another. |
+| `staging`  | Convention for internal / CI validation before promoting to production.                                     |
+| `beta`     | Convention for wider pre-production testing (e.g., QA teams, opt-in testers).                               |
+| _Any name_ | Tracks are created on demand. Any string is a valid track name.                                             |
+
+:::note
+
+Track names are arbitrary strings. `staging` and `beta` are community
+conventions, not reserved keywords. Use whatever naming convention makes sense
+for your team.
+
+:::
+
+## Publishing a patch to a track
+
+Pass the `--track` flag to any `shorebird patch` command. If you omit the flag,
+the patch is published to `stable` by default.
+
+<CodeTabs>
+
+```bash title="Android"
+shorebird patch android --track=staging
+```
+
+```bash title="iOS"
+shorebird patch ios --track=staging
+```
+
+```bash title="macOS"
+shorebird patch macos --track=staging
+```
+
+</CodeTabs>
+
+You can use any custom track name:
+
+```bash
+shorebird patch android --track=beta
+shorebird patch android --track=qa-team
+```
+
+## Previewing a patch on a specific track
+
+Use `shorebird preview` with the `--track` flag to run your app locally against
+a specific track's patches:
+
+```bash
+shorebird preview \
+  --app-id <your-app-id> \
+  --release-version 1.0.0+1 \
+  --track staging
+```
+
+This downloads the release and runs it on a connected device or emulator,
+applying the latest patch available on the specified track.
+
+## Promoting a patch between tracks
+
+Once you've validated a patch on a staging track, you can promote it to `stable`
+without rebuilding. This pushes the patch to all production users.
+
+### Via the Shorebird console
+
+Navigate to the release details page, click the **⋮** context menu next to the
+patch, choose **Change Track**, and select `stable` in the dialog that appears.
+
+### Via the CLI
+
+Promote a patch directly to `stable`:
+
+```bash
+shorebird patches promote \
+  --release-version 1.0.0+1 \
+  --patch-number 1
+```
+
+Or assign a patch to any track by name:
+
+```bash
+shorebird patches set-track \
+  --release-version 1.0.0+1 \
+  --patch-number 1 \
+  --track stable
+```
+
+## Subscribing a device to a track
+
+By default, devices always subscribe to the `stable` track. To have a device
+check a different track, you must:
+
+1. Add
+   [`package:shorebird_code_push`](https://pub.dev/packages/shorebird_code_push)
+   to your app.
+2. Set `auto_update: false` in your `shorebird.yaml` to disable the default
+   background updater.
+3. Call the updater manually with a `track` argument.
+
+```yaml title="shorebird.yaml"
+app_id: your-app-id-here
+auto_update: false
+```
+
+```dart
+import 'package:shorebird_code_push/shorebird_code_push.dart';
+
+final updater = ShorebirdUpdater();
+
+// Subscribe this device to the beta track
+await updater.update(track: UpdateTrack.beta);
+
+// Or use a custom track name
+await updater.update(track: UpdateTrack.custom('qa-team'));
+```
+
+:::tip
+
+`UpdateTrack.stable` and `UpdateTrack.beta` are convenience constants. For any
+other track name, use `UpdateTrack.custom('your-track-name')`.
+
+:::
+
+## Listing patches by track
+
+To see all patches for a release, including their track assignment, run:
+
+```bash
+shorebird patches list --release-version 1.0.0+1
+```
+
+The output shows each patch number, its active status, and the track it is
+currently assigned to.
+
+## Common patterns
+
+<LinkCard
+  href="/code-push/guides/staging-patches"
+  title="Staging Patches"
+  description="Walk through the full workflow of publishing to staging, previewing, and promoting to production."
+/>
+
+<LinkCard
+  href="/code-push/guides/testing-patches"
+  title="Testing Patches with a Subset of Users"
+  description="Route specific devices (e.g. your QA team) to a beta track using account-based logic or a hidden UI."
+/>
+
+<LinkCard
+  href="/code-push/guides/percentage-based-rollouts"
+  title="Percentage-Based Rollouts"
+  description="Gradually roll out patches to an increasing percentage of users using tracks and a cloud key-value store."
+/>
+
+## Frequently asked questions
+
+### How are Shorebird tracks different from Google Play testing tracks or Apple TestFlight?
+
+Google Play testing tracks (internal, alpha, closed testing, production) and
+Apple TestFlight are **app distribution** mechanisms that control which users
+can install a given version of your app from the store. Shorebird tracks are a
+**patch distribution** mechanism that controls which running devices receive a
+Dart code update.
+
+Shorebird has no built-in awareness of which Play track or TestFlight group a
+device is in. However, you can detect the install mechanism at runtime and use
+that signal to subscribe the device to the appropriate Shorebird track. See
+[Testing Patches](/code-push/guides/testing-patches#option-3-control-shorebird-track-based-on-how-the-app-was-installed)
+for more details.
+
+### Does rolling back a patch on one track affect other tracks?
+
+No. Tracks are independent. Rolling back or disabling a patch on `staging` has
+no effect on patches on the `stable` track, and vice versa.
+
+### Can a device be on multiple tracks at the same time?
+
+No. A device subscribes to exactly one track per update check. If your app logic
+changes the track dynamically (e.g., the user opts into a beta program), it will
+request patches from the new track on its next update check.
+
+### What happens if there is no patch on the requested track?
+
+If no patch is available on the requested track for the current release version,
+the device continues to run the base release (or the last successfully applied
+patch). It does **not** fall back to the `stable` track automatically.


### PR DESCRIPTION
## Summary

Tracks are referenced across multiple existing docs but there was no single
canonical page explaining what they are and how to use them. This PR adds a
dedicated Tracks reference page and wires up cross-references throughout the
docs.

## Changes

### New
- `code-push/tracks.mdx` — top-level reference page covering:
  - What tracks are and how they work (with a Mermaid flow diagram)
  - Built-in vs. custom tracks
  - Publishing a patch to a track (`--track` flag)
  - Previewing a patch on a specific track
  - Promoting a patch between tracks (console UI and CLI)
  - Subscribing a device to a track via `package:shorebird_code_push`
  - Listing patches by track
  - Links to related guides (staging patches, testing patches, percentage-based rollouts)
  - FAQ (tracks vs. Play/TestFlight tracks, rollback isolation, single-track-per-device behaviour)

### Modified
- `code-push/index.mdx` — added **Track** to the glossary alongside Application, Release, Patch, and Artifact
- `code-push/patch.mdx` — `--track` option row now links to the Tracks page
- `code-push/guides/testing-patches.mdx` — added a `LinkCard` pointing to the Tracks reference page
- `code-push/guides/staging-patches.mdx` — added a tip callout linking to the Tracks reference page
