### PR TITLE
chore: update Flutter to 3.44.9

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.8',
+  flutter: '3.44.9',
   dart: '3.12.2',
-  flutter_release_date: 'July 2026',
+  flutter_release_date: 'August 2026',
 };


### PR DESCRIPTION
## Summary

- Bump documented Flutter version to 3.44.9, shipped in shorebird_cli 1.6.116.
- Dart stays at 3.12.2. Flutter 3.44.9 carries no Dart base bump, so this was a Flutter-only rebase.
- Release date moves to August 2026.

## Testing

- Full 10-variant smoke matrix passed against the 3.44.9 RC. iOS and Android x {standalone, add-to-app} x {obfuscated, unobfuscated}, plus macOS standalone x {obfuscated, unobfuscated}.