### PR TITLE
docs: mark Shorebird CI as shut down

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -79,7 +79,8 @@ export default defineConfig({
           label: 'CI',
           collapsed: true,
           badge: {
-            text: 'beta',
+            text: 'deprecated',
+            variant: 'caution',
           },
           items: [{ autogenerate: { directory: 'ci' } }],
         },

--- a/src/content/docs/ci/checks/analyze.mdx
+++ b/src/content/docs/ci/checks/analyze.mdx
@@ -3,10 +3,9 @@ title: Analyze
 description: The details of the Analyze check in Shorebird CI
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/checks/check-spelling.mdx
+++ b/src/content/docs/ci/checks/check-spelling.mdx
@@ -3,10 +3,9 @@ title: Check Spelling
 description: The details of the Check Spelling check in Shorebird CI
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/checks/format.mdx
+++ b/src/content/docs/ci/checks/format.mdx
@@ -3,10 +3,9 @@ title: Format
 description: The details of the Format check in Shorebird CI
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/checks/index.mdx
+++ b/src/content/docs/ci/checks/index.mdx
@@ -3,10 +3,9 @@ title: Overview
 description: The landing page for the Checks detail section
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/checks/run-tests.mdx
+++ b/src/content/docs/ci/checks/run-tests.mdx
@@ -3,10 +3,9 @@ title: Run Tests
 description: The details of the Run Tests check in Shorebird CI
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/checks/upload-coverage.mdx
+++ b/src/content/docs/ci/checks/upload-coverage.mdx
@@ -3,10 +3,9 @@ title: Upload Coverage
 description: The details of the Upload Coverage check in Shorebird CI
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/faq.mdx
+++ b/src/content/docs/ci/faq.mdx
@@ -5,10 +5,9 @@ sidebar:
   order: 5
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
@@ -30,8 +29,6 @@ file an issue. The Shorebird team is happy to help.
   execution.
 - **Zero config** - Nothing to think about (or worry about keeping up to date).
   Shorebird CI just “does the right thing” for Flutter and Dart projects.
-  (Shorebird CI will eventually expose a small amount of configuration, but it’s
-  intentionally starting maximally simple.)
 - **Fast** - On par with GitHub actions (with room to make it faster still).
   Quick boot ups, uses similar (if slightly larger) machine instances, uses
   namespace.so’s fancy caching mechanism, etc.

--- a/src/content/docs/ci/index.mdx
+++ b/src/content/docs/ci/index.mdx
@@ -6,10 +6,9 @@ sidebar:
   order: 1
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/setup.mdx
+++ b/src/content/docs/ci/setup.mdx
@@ -7,10 +7,9 @@ sidebar:
   order: 2
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/uninstall.mdx
+++ b/src/content/docs/ci/uninstall.mdx
@@ -5,10 +5,9 @@ sidebar:
   order: 4
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/ci/view-logs.mdx
+++ b/src/content/docs/ci/view-logs.mdx
@@ -5,10 +5,9 @@ sidebar:
   order: 3
 ---
 
-:::caution[Shorebird CI is being deprecated]
+:::caution[Shorebird CI has been shut down]
 
-Shorebird CI will be shut down on **August 8, 2026**. New sign-ups are closed.
-Existing customers continue to run until the shutoff date. See the
+Shorebird CI was shut down on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 

--- a/src/content/docs/flutter-concepts/flutter-sdk-deep-dive.mdx
+++ b/src/content/docs/flutter-concepts/flutter-sdk-deep-dive.mdx
@@ -369,9 +369,8 @@ The most significant evolution for production Flutter teams is
 building a custom interpreter and novel per-function linker,
 [Shorebird solves the immutability problem](https://docs.shorebird.dev/code-push/system-architecture/)
 while maintaining app store compliance, enabling bug fixes in hours rather than
-days. Combined with [Shorebird CI's](https://docs.shorebird.dev/ci/) zero-config
-testing and modern static analysis practices, Flutter teams can ship confidently
-while retaining the ability to respond quickly to production issues.
+days, enabling Flutter teams to ship confidently while retaining the ability to
+respond quickly to production issues.
 
 ## Next steps
 


### PR DESCRIPTION
Shorebird CI was shut down on August 8, 2026. This PR updates the docs to reflect that.

## Changes

- Update caution banner across all CI pages from "will be shut down" (future) to "was shut down" (past) and remove the "new sign-ups are closed / existing customers continue to run" language
- Update sidebar CI badge from `beta` to `deprecated`
- Remove stale future-tense sentence in FAQ about CI "eventually" exposing configuration
- Remove Shorebird CI reference from the Flutter SDK deep dive article, as it's no longer an active product
