### PR TITLE
docs: add Arcade interactive demo to Initialize Shorebird page

### DIFF
--- a/src/content/docs/code-push/initialize.mdx
+++ b/src/content/docs/code-push/initialize.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 import { LinkCard } from 'starlight-theme-nova/components';
+import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
 
 :::note
 
@@ -15,6 +16,11 @@ If you are starting a new project, you can use
 Shorebird.
 
 :::
+
+<ArcadeEmbed
+  src="https://app.arcade.software/share/5w5LiD8ODdaGhb6554X9"
+  title="Initializing Shorebird in an existing Flutter project"
+/>
 
 To configure an existing Flutter project to use Shorebird, use `shorebird init`
 at the root of a Flutter project:


### PR DESCRIPTION
Adds an interactive Arcade walkthrough to the `shorebird init` documentation page, giving users a visual, step-by-step demo of initializing Shorebird in an existing Flutter project.

## Changes
- Added `ArcadeEmbed` component to `src/content/docs/code-push/initialize.mdx`
- Placed the embed near the top of the page (after the opening note), following the docs convention for Arcade embeds

## Demo
https://app.arcade.software/share/5w5LiD8ODdaGhb6554X9
