### PR TITLE
docs: add Arcade interactive demo to List Releases section

### DIFF
--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -7,6 +7,7 @@ sidebar:
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import ArcadeEmbed from '~/components/ArcadeEmbed.astro';
 import { LinkCard } from 'starlight-theme-nova/components';
 import { Image } from 'astro:assets';
 import releaseDeleteDialog from '~/assets/release_delete_dialog.png';
@@ -447,6 +448,11 @@ you can manage your app's releases directly from the command line using the
 `shorebird releases` commands.
 
 ### List releases
+
+<ArcadeEmbed
+  src="https://app.arcade.software/share/CtBj7r9AA5Xm0p0tIJYX"
+  title="Viewing releases from CLI and console"
+/>
 
 #### Via the Shorebird CLI
 


### PR DESCRIPTION
Adds an interactive Arcade walkthrough to the "List releases" section of the Create a Release page, showing users how to view releases from both the Shorebird CLI and the Shorebird console.

## Changes
- Added `ArcadeEmbed` component to `src/content/docs/code-push/release.mdx`
- Placed the embed at the top of the "List releases" section, before the CLI and console subsections

## Demo
https://app.arcade.software/share/CtBj7r9AA5Xm0p0tIJYX
