### PR TITLE
docs: add Arcade interactive demo to Create a Release page

### DIFF
--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -19,6 +19,11 @@ Creating a release builds and submits your app to Shorebird. Shorebird saves the
 compiled Dart code from your application in order to make updates smaller in
 size.
 
+<ArcadeEmbed
+  src="https://app.arcade.software/share/h8ywz1NWeFq3dC2iRQBU"
+  title="Create a Release"
+/>
+
 <Tabs>
 
 <TabItem value="release-android" label="Android">


### PR DESCRIPTION
Adds an interactive Arcade walkthrough to the Create a Release page, giving users a visual, step-by-step demo of creating a Shorebird release before diving into the platform-specific instructions.

## Changes
- Added `ArcadeEmbed` component to `src/content/docs/code-push/release.mdx`
- Placed the embed near the top of the page, after the intro paragraph and before the platform tabs

## Demo
https://app.arcade.software/share/h8ywz1NWeFq3dC2iRQBU
