### PR TITLE
docs: add Arcade interactive demo to Delete Release section

### DIFF
--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -503,6 +503,11 @@ your machine.
 
 ### Delete releases
 
+<ArcadeEmbed
+  src="https://app.arcade.software/share/1eUps58NpU5sFkTxljGu"
+  title="Delete a Release"
+/>
+
 :::danger
 
 Deleting a release will remove all associated patches and artifacts and is **not


### PR DESCRIPTION
Adds an interactive Arcade walkthrough to the "Delete releases" section of the Create a Release page, giving users a visual step-by-step guide for deleting a release from the Shorebird console.

## Changes
- Added `ArcadeEmbed` component to `src/content/docs/code-push/release.mdx`
- Placed the embed at the top of the "Delete releases" section, before the danger callout and written steps

## Demo
https://app.arcade.software/share/1eUps58NpU5sFkTxljGu
