### PR TITLE
chore: update Flutter to 3.47.0

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.44.9',
-  dart: '3.12.2',
+  flutter: '3.47.0',
+  dart: '3.13.0',
   flutter_release_date: 'August 2026',
 };


### PR DESCRIPTION
## Summary

- Flutter 3.47.0 and Dart 3.13.0, shipped in shorebird_cli 1.6.118.
- `flutter_release_date` stays August 2026 — upstream tagged 3.47.0 on 2026-08-11.

## Testing

- Versions match those published in the v1.6.118 release notes.