### PR TITLE
Revise Shorebird update timeline for Flutter releases

### DIFF
--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -167,10 +167,10 @@ find the details of this on the
 For specific versions by platform, please consult the
 [Flutter Version Management](/getting-started/flutter-version/) page.
 
-Shorebird tracks Flutter stable. Quarterly minor releases are updated within 5 business days of release. Patches are updated within 1
-business day. This process is
-automated, with an extra manual verification step before publishing to
-Shorebird's servers.
+Shorebird tracks Flutter stable. Quarterly minor releases are updated within 5
+business days of release. Patches are updated within 1 business day. This
+process is automated, with an extra manual verification step before publishing
+to Shorebird's servers.
 
 ### Can you use Shorebird with Flutter pre-release channels (Beta, Master)?
 

--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -167,8 +167,10 @@ find the details of this on the
 For specific versions by platform, please consult the
 [Flutter Version Management](/getting-started/flutter-version/) page.
 
-Shorebird tracks Flutter stable and releases updates to patches within 1 business days, and minor updates within 5 business days. This process is automated, with an extra manual verification
-step before publishing to Shorebird's servers.
+Shorebird tracks Flutter stable and releases updates to patches within 1
+business days, and minor updates within 5 business days. This process is
+automated, with an extra manual verification step before publishing to
+Shorebird's servers.
 
 ### Can you use Shorebird with Flutter pre-release channels (Beta, Master)?
 

--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -167,8 +167,7 @@ find the details of this on the
 For specific versions by platform, please consult the
 [Flutter Version Management](/getting-started/flutter-version/) page.
 
-Shorebird tracks Flutter stable and generally updates within a few hours of any
-stable release. This process is automated, with an extra manual verification
+Shorebird tracks Flutter stable and releases updates to patches within 1 business days, and minor updates within 5 business days. This process is automated, with an extra manual verification
 step before publishing to Shorebird's servers.
 
 ### Can you use Shorebird with Flutter pre-release channels (Beta, Master)?

--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -167,8 +167,8 @@ find the details of this on the
 For specific versions by platform, please consult the
 [Flutter Version Management](/getting-started/flutter-version/) page.
 
-Shorebird tracks Flutter stable and releases updates to patches within 1
-business days, and minor updates within 5 business days. This process is
+Shorebird tracks Flutter stable. Quarterly minor releases are updated within 5 business days of release. Patches are updated within 1
+business day. This process is
 automated, with an extra manual verification step before publishing to
 Shorebird's servers.
 

--- a/src/content/docs/getting-started/flutter-version.mdx
+++ b/src/content/docs/getting-started/flutter-version.mdx
@@ -16,8 +16,8 @@ version used by Shorebird CLI.
 ## Flutter update process
 
 Shorebird updates its fork of Flutter to stay current with the stable release.
-Patch updates to Flutter are made within 1 business day. Minor Flutter updates
-are made within 5 business days.
+Quarterly minor releases are updated within 5 business days of release. Patches are updated within 1
+business day.
 
 ## Supported Flutter versions
 

--- a/src/content/docs/getting-started/flutter-version.mdx
+++ b/src/content/docs/getting-started/flutter-version.mdx
@@ -16,8 +16,8 @@ version used by Shorebird CLI.
 ## Flutter update process
 
 Shorebird updates its fork of Flutter to stay current with the stable release.
-Quarterly minor releases are updated within 5 business days of release. Patches are updated within 1
-business day.
+Quarterly minor releases are updated within 5 business days of release. Patches
+are updated within 1 business day.
 
 ## Supported Flutter versions
 

--- a/src/content/docs/getting-started/flutter-version.mdx
+++ b/src/content/docs/getting-started/flutter-version.mdx
@@ -16,8 +16,8 @@ version used by Shorebird CLI.
 ## Flutter update process
 
 Shorebird updates its fork of Flutter to stay current with the stable release.
-Quarterly minor releases are updated within 5 business days of release. Patches
-are updated within 1 business day.
+Patch updates to Flutter are made within 1 business day. Minor Flutter updates
+are made within 5 business days.
 
 ## Supported Flutter versions
 


### PR DESCRIPTION
Updated the timeframe for Shorebird's Flutter updates to reflect that patches are released within 1 business day and minor updates within 5 business days.

<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

<!--- Describe your changes in detail -->
