### PR TITLE
chore: update Flutter to 3.47.1

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.47.0',
-  dart: '3.13.0',
+  flutter: '3.47.1',
+  dart: '3.13.1',
   flutter_release_date: 'August 2026',
 };


### PR DESCRIPTION
## Summary

- Bumps the documented Flutter version to 3.47.1 and Dart to 3.13.1, shipped in shorebird_cli 1.6.119.
- Docs-only. `consts.ts` is what renders the version numbers across the site.

## Testing

- Verified the values match the release: `flutter_release/3.47.1` resolves to Flutter 3.47.1, and DEPS pins `dart_revision` 852b3e36, which is Dart's 3.13.1 tag.