### PR TITLE
docs: make Flutter Versions a general Flutter reference

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -40,12 +40,14 @@ words:
   - cloudkms
   - codesign
   - codesigning
+  - cupertino
   - elif
   - evenodd
   - ffigen
   - fintech
   - frontmatter
   - gallego
+  - gles
   - graphql
   - geocodes
   - hotfixes
@@ -94,8 +96,11 @@ words:
   - shellenv
   - shorebirdtech
   - softwareupdate
+  - squircle
+  - squircles
   - subclassing
   - subosito
+  - superellipse
   - subview
   - tabler
   - temurin

--- a/.github/workflows/flutter-releases.yaml
+++ b/.github/workflows/flutter-releases.yaml
@@ -1,0 +1,52 @@
+name: flutter-releases
+
+# Fails when src/data/flutter-releases.json has fallen behind Flutter's release
+# feeds - a new stable, or a new patch on a line the table lists. The fix is to
+# run `npm run update-flutter-releases` and commit the result.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # 7am UTC, an hour after the ci build refreshes the site
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    env:
+      DATA_FILE: src/data/flutter-releases.json
+
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v7
+
+      - name: ⚙️ Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.14.0'
+
+      - name: 🐦 Check Flutter Release Data
+        run: |
+          COMMITTED=$(node -p "require('./$DATA_FILE').latestStable.version")
+          node scripts/update-flutter-releases.mjs
+          LATEST=$(node -p "require('./$DATA_FILE').latestStable.version")
+
+          if git diff --quiet -- "$DATA_FILE"; then
+            echo "Up to date. Latest stable Flutter is $LATEST."
+            exit 0
+          fi
+
+          if [ "$COMMITTED" != "$LATEST" ]; then
+            echo "::error::Flutter $LATEST is out, but the docs still list $COMMITTED as the latest stable."
+          else
+            echo "::error::Flutter shipped new patches since $DATA_FILE was last generated."
+          fi
+
+          echo "Run 'npm run update-flutter-releases' and commit the result."
+          echo "New release lines also need an entry in src/data/release-highlights.ts."
+          echo
+          git --no-pager diff -- "$DATA_FILE"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -19,18 +19,41 @@ Keys**. Without the key the page renders a fallback message instead of crashing.
 
 In CI the key is read from the `LINEAR_API_KEY` repository secret.
 
+## 🐦 Flutter release data
+
+The table on
+[Flutter Versions](https://docs.shorebird.dev/getting-started/flutter-version/)
+is generated from Flutter's public release feeds into
+`src/data/flutter-releases.json`. Regenerate it with:
+
+```sh
+npm run update-flutter-releases
+```
+
+The `flutter-releases` workflow runs the same script daily and fails when the
+committed file has fallen behind Flutter's stable channel, so a new release
+shows up as a red build rather than a stale page.
+
+The "Highlights" column is hand-written in `src/data/release-highlights.ts`,
+summarized from Flutter's release announcements. A new release line needs an
+entry there; without one the table falls back to a plain release-notes link.
+
+Both are separate from `src/consts.ts`, which tracks the Flutter version
+_Shorebird_ ships and is still bumped manually.
+
 ## 🧞 Commands
 
 All commands are run from the root of the project, from a terminal:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+| Command                           | Action                                           |
+| :-------------------------------- | :----------------------------------------------- |
+| `npm install`                     | Installs dependencies                            |
+| `npm run dev`                     | Starts local dev server at `localhost:4321`      |
+| `npm run build`                   | Build your production site to `./dist/`          |
+| `npm run preview`                 | Preview your build locally, before deploying     |
+| `npm run update-flutter-releases` | Refresh `src/data/flutter-releases.json`         |
+| `npm run astro ...`               | Run CLI commands like `astro add`, `astro check` |
+| `npm run astro -- --help`         | Get help using the Astro CLI                     |
 
 ## 👀 Want to learn more?
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "astro": "astro",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "update-flutter-releases": "node scripts/update-flutter-releases.mjs",
     "lint:content": "cspell --config .cspell.yaml \"**\"; vale --config=.vale.ini src/content/docs; node scripts/lint-component-labels.mjs"
   },
   "dependencies": {

--- a/scripts/update-flutter-releases.mjs
+++ b/scripts/update-flutter-releases.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Regenerates src/data/flutter-releases.json from Flutter's official release
+// feeds. Run with `npm run update-flutter-releases`; a scheduled workflow
+// (.github/workflows/flutter-releases.yaml) runs it daily and fails the build
+// if the committed file has fallen behind.
+//
+// The feeds list every build Flutter has ever shipped, per platform. What the
+// docs need is one row per release line (3.47, 3.44, ...) carrying its newest
+// patch, since Flutter only hotfixes the newest stable and there is never a
+// reason to sit on an older patch of a line.
+import { writeFileSync, readFileSync, existsSync } from 'node:fs';
+
+const PLATFORMS = ['macos', 'windows', 'linux'];
+const FEED_URL = (platform) =>
+  `https://storage.googleapis.com/flutter_infra_release/releases/releases_${platform}.json`;
+
+const OUTPUT_PATH = new URL(
+  '../src/data/flutter-releases.json',
+  import.meta.url,
+);
+
+// Flutter 2.x and earlier predate every version of Shorebird and are far
+// outside anything the docs recommend, so they are dropped at the source.
+const MIN_MAJOR = 3;
+
+const STABLE_VERSION = /^(\d+)\.(\d+)\.(\d+)$/;
+
+// Stable entries carry a bare "3.13.1", but some older ones use the beta-style
+// "3.13.0 (build 3.13.0-1.2.beta)". Keep just the version.
+function normalizeDartVersion(raw) {
+  if (!raw) return null;
+  return raw.split(' ')[0];
+}
+
+async function fetchFeed(platform) {
+  const response = await fetch(FEED_URL(platform));
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${platform} releases: ${response.status} ${response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+// Collapses the per-platform, per-architecture entries into one record per
+// stable version. A version is considered released on the earliest date any
+// platform published it.
+function collectStableVersions(feeds) {
+  const versions = new Map();
+
+  for (const feed of feeds) {
+    for (const release of feed.releases) {
+      if (release.channel !== 'stable') continue;
+
+      const match = STABLE_VERSION.exec(release.version);
+      if (!match) continue;
+
+      const [, major, minor, patch] = match.map(Number);
+      if (major < MIN_MAJOR) continue;
+
+      const existing = versions.get(release.version);
+      const releaseDate = release.release_date.slice(0, 10);
+      const dartVersion = normalizeDartVersion(release.dart_sdk_version);
+
+      if (!existing) {
+        versions.set(release.version, {
+          version: release.version,
+          major,
+          minor,
+          patch,
+          releaseDate,
+          dartVersion,
+        });
+        continue;
+      }
+
+      if (releaseDate < existing.releaseDate)
+        existing.releaseDate = releaseDate;
+      existing.dartVersion ??= dartVersion;
+    }
+  }
+
+  return [...versions.values()];
+}
+
+// One row per release line, newest first.
+function buildLines(stableVersions) {
+  const byLine = new Map();
+
+  for (const release of stableVersions) {
+    const line = `${release.major}.${release.minor}`;
+    const existing = byLine.get(line) ?? [];
+    existing.push(release);
+    byLine.set(line, existing);
+  }
+
+  const lines = [...byLine.entries()].map(([line, releases]) => {
+    releases.sort((a, b) => a.patch - b.patch);
+    const first = releases[0];
+    const latest = releases[releases.length - 1];
+
+    return {
+      line,
+      latestPatch: latest.version,
+      dartVersion: latest.dartVersion,
+      // When the line first shipped to stable, which is what makes a version
+      // "a year old" - not the date of its final hotfix.
+      releaseDate: first.releaseDate,
+      latestPatchDate: latest.releaseDate,
+      patchCount: releases.length,
+    };
+  });
+
+  lines.sort((a, b) => {
+    const [aMajor, aMinor] = a.line.split('.').map(Number);
+    const [bMajor, bMinor] = b.line.split('.').map(Number);
+    return bMajor - aMajor || bMinor - aMinor;
+  });
+
+  return lines;
+}
+
+// The newest stable Flutter, which is the answer to "what version of Flutter
+// is current". Read from the newest line rather than the feed's
+// `current_release.stable` hash so it stays consistent with the table.
+function buildLatestStable(lines) {
+  const newest = lines[0];
+  return {
+    version: newest.latestPatch,
+    dartVersion: newest.dartVersion,
+    releaseDate: newest.latestPatchDate,
+  };
+}
+
+const feeds = await Promise.all(PLATFORMS.map(fetchFeed));
+const lines = buildLines(collectStableVersions(feeds));
+
+if (lines.length === 0) {
+  throw new Error('No stable Flutter releases found; refusing to write.');
+}
+
+// No generation timestamp: the file should only change when Flutter ships
+// something, so a daily no-op run produces no diff and no pull request.
+const json = `${JSON.stringify({ latestStable: buildLatestStable(lines), lines }, null, 2)}\n`;
+
+const unchanged =
+  existsSync(OUTPUT_PATH) && readFileSync(OUTPUT_PATH, 'utf8') === json;
+
+writeFileSync(OUTPUT_PATH, json);
+
+console.log(
+  unchanged
+    ? `No change: ${lines.length} release lines, latest ${lines[0].latestPatch}.`
+    : `Updated: ${lines.length} release lines, latest ${lines[0].latestPatch}.`,
+);

--- a/src/components/FlutterReleaseTable.astro
+++ b/src/components/FlutterReleaseTable.astro
@@ -1,0 +1,177 @@
+---
+// Renders the newest patch of each recent Flutter release, with what that
+// release added. Versions and dates come from src/data/flutter-releases.json
+// (regenerate with `npm run update-flutter-releases`); the highlights are
+// hand-written in src/data/release-highlights.ts.
+import {
+  releaseLines,
+  formatAge,
+  formatMonth,
+  monthsSince,
+} from '~/data/releases';
+import { releaseHighlights, releaseNotesUrl } from '~/data/release-highlights';
+
+// Flutter ships roughly four releases a year, so ten rows covers about the
+// last two and a half years. Older releases are a link to Flutter's archive
+// rather than a row here.
+const LINES_SHOWN = 10;
+
+// Rows visible before the reader asks for more. Every row is still in the
+// HTML - the extras are collapsed by the script below, not omitted - so search
+// engines and assistants read the whole table.
+const INITIAL_ROWS = 5;
+
+// Shorebird recommends against shipping on a release older than this.
+const RECOMMENDED_MAX_AGE_MONTHS = 12;
+
+const rows = releaseLines.slice(0, LINES_SHOWN).map((line, index) => {
+  const age = monthsSince(line.releaseDate);
+  const aged = age >= RECOMMENDED_MAX_AGE_MONTHS;
+
+  return {
+    ...line,
+    released: formatMonth(line.releaseDate),
+    age: formatAge(age),
+    highlight: releaseHighlights[line.line],
+    notesUrl: releaseNotesUrl(line.line),
+    extra: index >= INITIAL_ROWS,
+    // Older releases stay fully legible - people come here to look a version
+    // up, not only to be told to move off it. The verdict carries the color.
+    recommendation:
+      index === 0
+        ? { label: 'Latest stable', tone: 'latest' }
+        : aged
+          ? { label: 'Upgrade', tone: 'upgrade' }
+          : { label: 'Yes', tone: 'yes' },
+  };
+});
+
+const hiddenCount = rows.filter((row) => row.extra).length;
+---
+
+<div class="flutter-releases-wrapper">
+  <table class="flutter-releases">
+    <thead>
+      <tr>
+        <th>Flutter</th>
+        <th>First released</th>
+        <th>Highlights</th>
+        <th>Recommended</th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        rows.map((row) => (
+          <tr class={row.extra ? 'extra' : undefined}>
+            <td>
+              <a href={row.notesUrl}>{row.latestPatch}</a>
+              <span class="sub">Dart {row.dartVersion}</span>
+            </td>
+            <td>
+              {row.released}
+              {row.age && <span class="sub">{row.age}</span>}
+            </td>
+            <td>{row.highlight ?? '—'}</td>
+            <td class={`verdict ${row.recommendation.tone}`}>
+              {row.recommendation.label}
+            </td>
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+
+  {
+    hiddenCount > 0 && (
+      <button class="show-more" type="button" aria-expanded="true" hidden>
+        Show {hiddenCount} older releases
+      </button>
+    )
+  }
+</div>
+
+<script>
+  // Progressive enhancement: the table ships fully expanded so it still reads
+  // correctly with no JavaScript, and only collapses once this runs.
+  const wrapper = document.querySelector('.flutter-releases-wrapper');
+  const table = wrapper?.querySelector('.flutter-releases');
+  const button = wrapper?.querySelector<HTMLButtonElement>('.show-more');
+
+  if (table && button) {
+    const hiddenCount = table.querySelectorAll('tr.extra').length;
+
+    const setCollapsed = (collapsed: boolean) => {
+      table.classList.toggle('collapsed', collapsed);
+      button.setAttribute('aria-expanded', String(!collapsed));
+      button.textContent = collapsed
+        ? `Show ${hiddenCount} older releases`
+        : 'Show fewer releases';
+    };
+
+    setCollapsed(true);
+    button.hidden = false;
+    button.addEventListener('click', () =>
+      setCollapsed(!table.classList.contains('collapsed')),
+    );
+  }
+</script>
+
+<style>
+  .flutter-releases {
+    width: 100%;
+  }
+
+  /* Wide enough to keep "Dart 3.13.1" on one line under the version, and
+     "December 2024" on one line in the date column. Without these the
+     highlights column takes every spare pixel and both wrap awkwardly. */
+  .flutter-releases td:first-child {
+    min-width: 7rem;
+    font-weight: 600;
+  }
+
+  .flutter-releases td:nth-child(2) {
+    min-width: 8rem;
+  }
+
+  .flutter-releases .sub {
+    display: block;
+    font-size: var(--sl-text-xs);
+    font-weight: 400;
+    color: var(--sl-color-gray-3);
+  }
+
+  .flutter-releases .verdict {
+    font-weight: 600;
+  }
+
+  .flutter-releases .verdict.latest {
+    color: var(--sl-color-green-high);
+  }
+
+  .flutter-releases .verdict.upgrade {
+    color: var(--sl-color-orange-high);
+  }
+
+  .flutter-releases .verdict.yes {
+    font-weight: inherit;
+    color: var(--sl-color-gray-3);
+  }
+
+  .flutter-releases.collapsed tr.extra {
+    display: none;
+  }
+
+  .show-more {
+    margin-top: 0.25rem;
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    font-size: var(--sl-text-sm);
+    color: var(--sl-color-text-accent);
+  }
+
+  .show-more:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/components/LatestFlutter.astro
+++ b/src/components/LatestFlutter.astro
@@ -1,0 +1,46 @@
+---
+// The answer most people arrive on this page looking for, stated as one plain
+// sentence so a search engine or an assistant can lift it directly, and styled
+// to carry the weight that sentence deserves.
+import { latestStable, latestStableDate } from '~/data/releases';
+---
+
+<div class="latest-flutter">
+  <p class="label">Latest stable Flutter</p>
+  <p class="statement">
+    The latest stable version of Flutter is <strong>{latestStable.version}</strong
+    >, released on {latestStableDate}. It ships with Dart {
+      latestStable.dartVersion
+    }.
+  </p>
+</div>
+
+<style>
+  .latest-flutter {
+    margin-block: 1.5rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--sl-color-hairline-light);
+    border-left: 4px solid var(--sl-color-accent);
+    border-radius: 0.5rem;
+    background-color: var(--sl-color-bg-sidebar);
+  }
+
+  .latest-flutter .label {
+    margin: 0;
+    font-size: var(--sl-text-xs);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--sl-color-gray-3);
+  }
+
+  .latest-flutter .statement {
+    margin: 0.35rem 0 0;
+    font-size: var(--sl-text-lg);
+    line-height: 1.5;
+  }
+
+  .latest-flutter strong {
+    color: var(--sl-color-white);
+  }
+</style>

--- a/src/content/docs/getting-started/flutter-version.mdx
+++ b/src/content/docs/getting-started/flutter-version.mdx
@@ -1,17 +1,56 @@
 ---
-title: Flutter Version Management
-description: How to manage your Shorebird Flutter version
+title: Flutter Versions
+description:
+  The current stable release of Flutter, the newest patch of every recent
+  release, and which versions Shorebird supports.
 sidebar:
   order: 2
 ---
+
+import LatestFlutter from '~/components/LatestFlutter.astro';
+import FlutterReleaseTable from '~/components/FlutterReleaseTable.astro';
+import { latestStable, currentLine, previousLine } from '~/data/releases';
+
+<LatestFlutter />
+
+## Which Flutter version should you use?
+
+Shorebird recommends the latest stable release, **{latestStable.version}**.
+
+Whatever release you are on, run its latest patch. Patches exist because
+something was broken, and there is rarely a downside to taking the newest one.
+
+Large enterprises often stay exactly one release behind, which today means
+**{previousLine.latestPatch}**. Wherever you land, keep it less than 12 months
+old.
+
+## Recent Flutter releases
+
+Flutter opens a new release roughly every quarter — {previousLine.line}, then
+{currentLine.line} — and issues hotfix patches against it as bugs are found.
+Only the newest release gets hotfixes, so a fix that lands in {currentLine.line}
+is generally not backported.
+
+Each row below is the newest patch of a release, the Dart SDK version it
+bundles, and the headline changes it brought. Use the version in the first
+column; it links to Flutter's full release notes.
+
+<FlutterReleaseTable />
+
+For releases older than these, see Flutter's
+[release archive](https://docs.flutter.dev/release/archive). For what a specific
+patch fixed, see the
+[hotfix changelog](https://github.com/flutter/flutter/blob/stable/CHANGELOG.md).
+
+## Shorebird and Flutter versions
 
 Shorebird works with a wide range of Flutter versions and uses a private cache
 of Flutter installs which it will automatically manage for you to match your
 desired Flutter version.
 
 When Shorebird CLI is installed, it pulls down the latest stable version of
-Shorebird's Flutter. This section covers how to list and change the Flutter
-version used by Shorebird CLI.
+Shorebird's Flutter, currently %flutter_version%. This section covers how to
+list and change the Flutter version used by Shorebird CLI.
 
 ## Flutter update process
 
@@ -19,7 +58,7 @@ Shorebird updates its fork of Flutter to stay current with the stable release.
 Quarterly minor releases are updated within 5 business days of release. Patches
 are updated within 1 business day.
 
-## Supported Flutter versions
+### Supported Flutter versions
 
 | Platform | Minimum Flutter Version | Minimum Shorebird Version |
 | -------- | ----------------------- | ------------------------- |
@@ -33,7 +72,7 @@ Shorebird recommends using the latest stable version of Flutter whenever
 possible. Changes to Shorebird are not currently backported to previous releases
 of Flutter.
 
-## List Flutter versions
+### List Flutter versions
 
 To list all Flutter versions Shorebird has published, use the
 `shorebird flutter versions list` command.
@@ -47,7 +86,7 @@ Another way to see the current Flutter version is by running
 
 :::
 
-## Use a different Flutter version
+### Use a different Flutter version
 
 By default, Shorebird will use the latest stable version of Flutter. If you need
 to create a release with a different version of Flutter, you can use the
@@ -67,7 +106,7 @@ always be built with the version of Flutter used by the release.
 
 :::
 
-## Flutter version notes
+### Flutter version notes
 
 To help you avoid hidden pitfalls, Shorebird maintains version notes on Flutter
 releases that have known issues affecting releasing apps or patching. Check here

--- a/src/data/flutter-releases.json
+++ b/src/data/flutter-releases.json
@@ -1,0 +1,145 @@
+{
+  "latestStable": {
+    "version": "3.47.1",
+    "dartVersion": "3.13.1",
+    "releaseDate": "2026-08-19"
+  },
+  "lines": [
+    {
+      "line": "3.47",
+      "latestPatch": "3.47.1",
+      "dartVersion": "3.13.1",
+      "releaseDate": "2026-08-12",
+      "latestPatchDate": "2026-08-19",
+      "patchCount": 2
+    },
+    {
+      "line": "3.44",
+      "latestPatch": "3.44.9",
+      "dartVersion": "3.12.2",
+      "releaseDate": "2026-05-18",
+      "latestPatchDate": "2026-08-06",
+      "patchCount": 10
+    },
+    {
+      "line": "3.41",
+      "latestPatch": "3.41.9",
+      "dartVersion": "3.11.5",
+      "releaseDate": "2026-02-11",
+      "latestPatchDate": "2026-04-30",
+      "patchCount": 10
+    },
+    {
+      "line": "3.38",
+      "latestPatch": "3.38.10",
+      "dartVersion": "3.10.9",
+      "releaseDate": "2025-11-12",
+      "latestPatchDate": "2026-02-11",
+      "patchCount": 11
+    },
+    {
+      "line": "3.35",
+      "latestPatch": "3.35.7",
+      "dartVersion": "3.9.2",
+      "releaseDate": "2025-08-14",
+      "latestPatchDate": "2025-10-23",
+      "patchCount": 8
+    },
+    {
+      "line": "3.32",
+      "latestPatch": "3.32.8",
+      "dartVersion": "3.8.1",
+      "releaseDate": "2025-05-20",
+      "latestPatchDate": "2025-07-25",
+      "patchCount": 9
+    },
+    {
+      "line": "3.29",
+      "latestPatch": "3.29.3",
+      "dartVersion": "3.7.2",
+      "releaseDate": "2025-02-12",
+      "latestPatchDate": "2025-04-14",
+      "patchCount": 4
+    },
+    {
+      "line": "3.27",
+      "latestPatch": "3.27.4",
+      "dartVersion": "3.6.2",
+      "releaseDate": "2024-12-11",
+      "latestPatchDate": "2025-02-05",
+      "patchCount": 5
+    },
+    {
+      "line": "3.24",
+      "latestPatch": "3.24.5",
+      "dartVersion": "3.5.4",
+      "releaseDate": "2024-08-06",
+      "latestPatchDate": "2024-11-14",
+      "patchCount": 6
+    },
+    {
+      "line": "3.22",
+      "latestPatch": "3.22.3",
+      "dartVersion": "3.4.4",
+      "releaseDate": "2024-05-13",
+      "latestPatchDate": "2024-07-18",
+      "patchCount": 4
+    },
+    {
+      "line": "3.19",
+      "latestPatch": "3.19.6",
+      "dartVersion": "3.3.4",
+      "releaseDate": "2024-02-15",
+      "latestPatchDate": "2024-04-17",
+      "patchCount": 7
+    },
+    {
+      "line": "3.16",
+      "latestPatch": "3.16.9",
+      "dartVersion": "3.2.6",
+      "releaseDate": "2023-11-15",
+      "latestPatchDate": "2024-01-25",
+      "patchCount": 10
+    },
+    {
+      "line": "3.13",
+      "latestPatch": "3.13.9",
+      "dartVersion": "3.1.5",
+      "releaseDate": "2023-08-16",
+      "latestPatchDate": "2023-10-25",
+      "patchCount": 10
+    },
+    {
+      "line": "3.10",
+      "latestPatch": "3.10.6",
+      "dartVersion": "3.0.6",
+      "releaseDate": "2023-05-10",
+      "latestPatchDate": "2023-07-12",
+      "patchCount": 7
+    },
+    {
+      "line": "3.7",
+      "latestPatch": "3.7.12",
+      "dartVersion": "2.19.6",
+      "releaseDate": "2023-01-24",
+      "latestPatchDate": "2023-04-20",
+      "patchCount": 13
+    },
+    {
+      "line": "3.3",
+      "latestPatch": "3.3.10",
+      "dartVersion": "2.18.6",
+      "releaseDate": "2022-08-30",
+      "latestPatchDate": "2022-12-15",
+      "patchCount": 11
+    },
+    {
+      "line": "3.0",
+      "latestPatch": "3.0.5",
+      "dartVersion": "2.17.6",
+      "releaseDate": "2022-05-11",
+      "latestPatchDate": "2022-07-13",
+      "patchCount": 6
+    }
+  ]
+}

--- a/src/data/release-highlights.ts
+++ b/src/data/release-highlights.ts
@@ -1,0 +1,38 @@
+// What each Flutter release line actually gave you, so the version table
+// answers "why would I move to this one" and not just "what number is it".
+//
+// Hand-written on purpose. Flutter's release feeds carry versions and dates but
+// nothing about what changed, and the headline of a release is an editorial
+// call - so these are summarized from Flutter's own release announcements
+// rather than generated. Add a line here when Flutter opens a new one; the
+// table renders a dash for any line without an entry.
+//
+// Keep each entry to one short phrase covering the one or two changes a
+// developer would actually upgrade for. The linked release notes carry the
+// full list.
+export const releaseHighlights: Record<string, string> = {
+  '3.47':
+    'Impeller became the default renderer on macOS, Windows, and Linux; Material and Cupertino split into standalone packages',
+  '3.44':
+    'Swift Package Manager replaced CocoaPods as the default for iOS and macOS; Hybrid Composition++ for Android platform views',
+  '3.41':
+    'Platform-specific assets in pubspec.yaml, Android Gradle Plugin 9 support, and Navigator.popUntilWithResult',
+  '3.38':
+    'Dart dot shorthands, so .start works where MainAxisAlignment.start was required; widget previews in VS Code and Android Studio',
+  '3.35':
+    'Squircle corners across most Cupertino widgets, CupertinoExpansionTile, and lower iOS startup latency',
+  '3.32':
+    'Hot reload on the web (experimental) and Cupertino squircles via RoundedSuperellipseBorder',
+  '3.29':
+    'Impeller on OpenGLES for Android devices without Vulkan, and Dart running on the platform main thread on Android and iOS',
+  '3.27':
+    'Impeller became the default renderer on modern Android; spacing on Row and Column',
+  '3.24': 'Flutter GPU preview and multi-view embedding for Flutter web',
+  '3.22':
+    'WebAssembly on the stable channel for web, and a feature-complete Vulkan backend for Impeller on Android',
+};
+
+/** Flutter publishes release notes per line, keyed off the .0 release. */
+export function releaseNotesUrl(line: string): string {
+  return `https://docs.flutter.dev/release/release-notes/release-notes-${line}.0`;
+}

--- a/src/data/releases.ts
+++ b/src/data/releases.ts
@@ -1,0 +1,79 @@
+// Typed accessors and date formatting for the generated Flutter release data
+// in flutter-releases.json. Regenerate that file with
+// `npm run update-flutter-releases`.
+//
+// Pages read from here rather than importing the JSON directly so that dates
+// are formatted one way everywhere, and so the docs never have to hand-edit a
+// version number that Flutter has already superseded.
+import data from './flutter-releases.json';
+
+export interface ReleaseLine {
+  /** The release line, e.g. "3.47". */
+  line: string;
+  /** Newest patch of the line, e.g. "3.47.1". */
+  latestPatch: string;
+  /** Dart SDK version bundled with `latestPatch`. */
+  dartVersion: string;
+  /** When the line first reached stable, e.g. "2026-08-12". */
+  releaseDate: string;
+  /** When `latestPatch` shipped. */
+  latestPatchDate: string;
+  patchCount: number;
+}
+
+export interface LatestStable {
+  version: string;
+  dartVersion: string;
+  releaseDate: string;
+}
+
+export const latestStable: LatestStable = data.latestStable;
+export const releaseLines: ReleaseLine[] = data.lines;
+
+export const currentLine = releaseLines[0]!;
+export const previousLine = releaseLines[1]!;
+
+export function formatLongDate(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('en-US', {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  });
+}
+
+export function formatMonth(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/** Whole months between `isoDate` and now. */
+export function monthsSince(isoDate: string, now = new Date()): number {
+  const then = new Date(isoDate);
+  const months =
+    (now.getUTCFullYear() - then.getUTCFullYear()) * 12 +
+    (now.getUTCMonth() - then.getUTCMonth());
+  return now.getUTCDate() < then.getUTCDate() ? months - 1 : months;
+}
+
+/**
+ * Human-readable age, or null for anything less than a month old: the newest
+ * release line is days old, and restating that under its release date is noise
+ * rather than information.
+ */
+export function formatAge(months: number): string | null {
+  if (months < 1) return null;
+  if (months === 1) return '1 month ago';
+  if (months < 12) return `${months} months ago`;
+
+  const years = Math.floor(months / 12);
+  const remainder = months % 12;
+  const yearLabel = years === 1 ? '1 year' : `${years} years`;
+  if (remainder === 0) return `${yearLabel} ago`;
+
+  const monthLabel = remainder === 1 ? '1 month' : `${remainder} months`;
+  return `${yearLabel} ${monthLabel} ago`;
+}
+
+export const latestStableDate = formatLongDate(latestStable.releaseDate);


### PR DESCRIPTION
## Status

**READY**

## Description

`/getting-started/flutter-version/` ranks around position 8 for the "what Flutter version is current" query cluster, but the page answers a Shorebird-specific question instead. This restructures it so the top half is useful to any Flutter developer and the Shorebird material sits below it.

### Page

- **Leads with the current stable release** in a callout, as one plain sentence rather than a stat block, so a search engine or assistant can lift it directly.
- **Tightened the recommendation prose** to three short paragraphs: latest stable, run the newest patch of whatever you're on, and the one-release-behind case that large enterprises use.
- **New release table** — newest patch of each recent release, its Dart SDK version, when it first shipped, and the headline changes it brought. Five rows show by default with a "Show 5 older releases" toggle. All ten rows ship in the HTML and collapse client-side, so crawlers and assistants read the whole table and it degrades to fully expanded with JS off.
- **Existing Shorebird version notes are unchanged**, now under a new "Shorebird and Flutter versions" heading. `#supported-flutter-versions` and `#use-a-different-flutter-version` keep their ids — Google indexes both as separate results.

### Data

- `scripts/update-flutter-releases.mjs` merges Flutter's three platform release feeds into `src/data/flutter-releases.json` (one row per release, newest patch, Dart version, dates). Run it with `npm run update-flutter-releases`. No generation timestamp, so a no-op run produces no diff.
- `.github/workflows/flutter-releases.yaml` runs daily and **fails** when the committed file has fallen behind stable, with a message naming the new version. It does not open a PR. Both paths were exercised locally.
- Highlights are hand-written in `src/data/release-highlights.ts`, summarized from Flutter's own release announcements — the feeds carry versions and dates but nothing about what changed. A release with no entry renders a dash.

Note that this is all separate from `src/consts.ts`, which tracks the Flutter version *Shorebird* ships and is still bumped by hand. The page distinguishes the two.

### Checks

`npm run build`, `format:check`, cspell, Vale, and the component-label lint all pass locally. Verified the table and callout in light and dark, and the toggle in a browser.

### Follow-ups, not in this PR

- Per-release "known issues" commentary sourced from the version-quality data in the admin dashboard, rather than the static notes list.
- Disclosure triangles for per-release detail — the data is already keyed per release.
