### PR TITLE
chore: update Flutter to 3.47.2

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  flutter: '3.47.1',
-  dart: '3.13.1',
+  flutter: '3.47.2',
+  dart: '3.13.2',
   flutter_release_date: 'August 2026',
 };


### PR DESCRIPTION
## Summary

- Bump the documented Flutter version to 3.47.2 and Dart to 3.13.2, matching the 1.6.120 release.
- Release date stays August 2026, so `flutter_release_date` is unchanged.

## Testing

- Verified against the shipped release: `flutter_release/3.47.2` resolves to `e16cf749cca` in the Flutter fork, built on dart-sdk `52183de` (Dart 3.13.2).