### PR TITLE
docs: finish the SAML metadata-URL pass

### DIFF
--- a/src/content/docs/enterprise/saml.mdx
+++ b/src/content/docs/enterprise/saml.mdx
@@ -15,7 +15,7 @@ through your identity provider (IdP) instead of a personal Google or Microsoft
 account.
 
 SAML is not self-serve yet. The Shorebird team creates the connection for you:
-gather the values described below, send them to
+send what is described below to
 [contact@shorebird.dev](mailto:contact@shorebird.dev), and Shorebird will
 activate SSO for your email domain and confirm when it is live.
 
@@ -42,7 +42,7 @@ A few consequences of this design are worth knowing before you start:
   the app tile in the Okta dashboard, is not supported.
 - **One connection per email domain.** The email address in the assertion must
   be at the connection's domain, or sign-in is rejected. If your team uses
-  several domains, send the values for each one and Shorebird will create a
+  several domains, send a metadata URL for each one and Shorebird will create a
   connection per domain.
 - **SSO covers authentication only.** Assigning the app to a user in your IdP
   does not add them to your Shorebird organization. Membership and roles are
@@ -60,13 +60,18 @@ Two things:
 - **Your email domain**, such as `acme.com`. This is what routes a member's
   sign-in to your IdP, and it is the one value the metadata does not contain.
 
+Also mention any members who already have a Shorebird account created with
+Google or Microsoft using an address at that domain. Those accounts need to be
+migrated to the new connection, and without the migration their first SSO
+sign-in fails.
+
 ### If your IdP publishes no metadata URL
 
 Some providers, Google Workspace among them, offer metadata only as a download.
 Send the XML file itself, or pull these three values out of it and send those
 instead:
 
-| Value                   | Where to find it in Okta                                  | Example                                                                 |
+| Value                   | Where to find it (Okta example)                           | Example                                                                 |
 | ----------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
 | IdP Entity ID           | "Identity Provider Issuer" in the SAML setup instructions | `http://www.okta.com/exk1a2b3c4EXAMPLE`                                 |
 | IdP SSO URL             | "Identity Provider Single Sign-On URL"                    | `https://acme.okta.com/app/acme_shorebird_1/exk1a2b3c4EXAMPLE/sso/saml` |
@@ -76,11 +81,6 @@ None of the three is optional. The certificate in particular is what Shorebird
 uses to verify that an assertion really came from your IdP, so send it as PEM
 text, including the `-----BEGIN CERTIFICATE-----` and
 `-----END CERTIFICATE-----` lines.
-
-Also mention any members who already have a Shorebird account created with
-Google or Microsoft using an address at that domain. Those accounts need to be
-migrated to the new connection, and without the migration their first SSO
-sign-in fails.
 
 ## Settings to use in your identity provider
 
@@ -131,9 +131,9 @@ address, so configure the attribute statement explicitly:
 
 5. Click **Next**, answer the feedback questions, and click **Finish**.
 
-6. On the app's **Sign On** tab, open **View SAML setup instructions** to see
-   the issuer, SSO URL, and certificate, or copy the **Identity Provider
-   metadata** link.
+6. On the app's **Sign On** tab, copy the **Identity Provider metadata** link.
+   **View SAML setup instructions**, on the same tab, shows the issuer, SSO URL,
+   and certificate individually if you ever need them.
 
 7. [Assign the app](https://help.okta.com/en-us/content/topics/provisioning/lcm/lcm-assign-app-user.htm)
    to the users and groups who should have access to Shorebird.
@@ -150,7 +150,7 @@ For background on how the pieces fit together, see Okta's
 
 Other SAML 2.0 providers, such as Microsoft Entra ID, Google Workspace,
 OneLogin, and JumpCloud, work the same way. The field names differ, but the
-values Shorebird needs are the same.
+metadata document and the settings Shorebird needs are the same.
 
 ## After activation
 
@@ -164,8 +164,13 @@ match on both sides.
 
 When your IdP's signing certificate rotates, email
 [contact@shorebird.dev](mailto:contact@shorebird.dev) before the old one
-expires, and Shorebird will re-read your metadata. A stored certificate that no
-longer matches the IdP will break sign-in for everyone on the domain.
+expires, and Shorebird will re-read your metadata. Shorebird keeps every
+certificate the document lists, so if your IdP publishes the new certificate
+alongside the old one before the switch, that re-read covers the rotation with
+no interruption. If your connection was created from values sent by hand,
+include the new certificate in that email, and the old one too if it is still in
+use. A stored certificate that no longer matches the IdP will break sign-in for
+everyone on the domain.
 
 ## Troubleshooting
 


### PR DESCRIPTION
#635 switched the ask from four values to a metadata URL, but left a few
spots on the page still written for the old ask.

- The intro ("gather the values described below") and the multi-domain
  bullet ("send the values for each one") still describe a list of values.
- The note about members who already have a Google/Microsoft account at
  the domain had ended up *inside* the "If your IdP publishes no metadata
  URL" subsection, so it read as applying only to that fallback path. It
  applies to every connection — moved back up under the two-item ask.
- Okta step 6 still led with **View SAML setup instructions**, and offered
  the metadata link as the alternative. Now the other way round.
- Certificate rotation said Shorebird "will re-read your metadata", which
  is not true for a connection created from hand-entered values.

Two things added from the landed admin behavior: importing keeps every
signing certificate the metadata lists, so a customer who publishes the
new certificate alongside the old one before the switch can rotate with
no downtime; and the fallback table's Okta column is now labeled as an
example, since that section is aimed at providers that publish no
metadata URL.

Verified against `web/apps/admin/app/routes/saml._index.tsx` and
`saml-metadata.server.ts`: the import dialog takes a metadata URL or
pasted XML, so the page's "send the XML file itself" fallback is
accurate.

Prettier and cspell pass. Vale isn't installed in this checkout, so it
did not run; no headings changed.
