### PR TITLE
docs: deprecate Shorebird CI

### DIFF
--- a/src/content/docs/ci/checks/analyze.mdx
+++ b/src/content/docs/ci/checks/analyze.mdx
@@ -3,31 +3,10 @@ title: Analyze
 description: The details of the Analyze check in Shorebird CI
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
-
-Shorebird CI's "Analyze" check uses
-[`dart analyze`](https://dart.dev/tools/dart-analyze) to perform static analysis
-across all of your Dart files.
-
-## Requirements
-
-None. As long as your repository has Dart code detected this check will run.
-
-If you have an `analysis_options.yaml` file with customizations, they are
-recognized during this check.
-
-## Available statuses
-
-### Pass
-
-This check passes if the check returns `No issues found!`.
-
-### Fail
-
-This check fails if the check finds any analysis issues.

--- a/src/content/docs/ci/checks/check-spelling.mdx
+++ b/src/content/docs/ci/checks/check-spelling.mdx
@@ -3,30 +3,11 @@ title: Check Spelling
 description: The details of the Check Spelling check in Shorebird CI
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-Shorebird CI's "Check Spelling" check uses [CSpell](https://cspell.org) to look
-for misspelled words in your code base.
-
-## Requirements
-
-This check only runs if a CSpell Config file is found in the repository. For
-more information on this please consult the
-[Getting Started in CSpell Docs](https://cspell.org/docs/getting-started#1-create-a-configuration-file)
-for details.
-
-## Available statuses
-
-### Pass
-
-This check passes if the check returns `Issues found: 0 in 0 files`.
-
-### Fail
-
-This check fails if the check finds any misspellings in any files.

--- a/src/content/docs/ci/checks/check-spelling.mdx
+++ b/src/content/docs/ci/checks/check-spelling.mdx
@@ -10,4 +10,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-

--- a/src/content/docs/ci/checks/format.mdx
+++ b/src/content/docs/ci/checks/format.mdx
@@ -3,31 +3,11 @@ title: Format
 description: The details of the Format check in Shorebird CI
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-Shorebird CI's "Format" check uses
-[`dart format`](https://dart.dev/tools/dart-format) to look for consistent
-formatting across all of your Dart files.
-
-## Requirements
-
-None. As long as your repository has Dart code detected this check will run.
-
-If you have an `analysis_options.yaml` file with customizations, they are
-recognized during this check.
-
-## Available statuses
-
-### Pass
-
-This check passes if the check returns `0 changed`.
-
-### Fail
-
-This check fails if the check finds changes in files.

--- a/src/content/docs/ci/checks/format.mdx
+++ b/src/content/docs/ci/checks/format.mdx
@@ -10,4 +10,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-

--- a/src/content/docs/ci/checks/index.mdx
+++ b/src/content/docs/ci/checks/index.mdx
@@ -3,15 +3,12 @@ title: Overview
 description: The landing page for the Checks detail section
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-Shorebird CI contains a number of checks built into the system. With each run
-all checks are automatically ran with no need for setup from you or your team.
 
-For details on each check please view the detail pages.

--- a/src/content/docs/ci/checks/index.mdx
+++ b/src/content/docs/ci/checks/index.mdx
@@ -10,5 +10,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-
-

--- a/src/content/docs/ci/checks/run-tests.mdx
+++ b/src/content/docs/ci/checks/run-tests.mdx
@@ -3,28 +3,10 @@ title: Run Tests
 description: The details of the Run Tests check in Shorebird CI
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
-
-Shorebird CI's "Run Test" check will run any test files that are found to ensure
-they are passing.
-
-## Requirements
-
-None. As long as your repository has Dart or Flutter tests detected this check
-will run.
-
-## Available statuses
-
-### Pass
-
-This check passes if the check returns `0 failed`.
-
-### Fail
-
-This check fails if the check returns with any number of failed tests above 0.

--- a/src/content/docs/ci/checks/upload-coverage.mdx
+++ b/src/content/docs/ci/checks/upload-coverage.mdx
@@ -3,31 +3,11 @@ title: Upload Coverage
 description: The details of the Upload Coverage check in Shorebird CI
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-Shorebird CI's "Upload Coverage" check will upload your coverage report to
-[Codecov](https://about.codecov.io) in order to see a comprehensive history of
-your coverage for your code base.
-
-## Requirements
-
-This check only runs if a Codecov Config file is found in the repository. For
-more information on this please consult the
-[Codecov YAML documentation](https://docs.codecov.com/docs/codecov-yaml) for
-details.
-
-## Available statuses
-
-### Pass
-
-This check passes if the check returns `Process Upload complete`.
-
-### Fail
-
-This check fails if the check returns an error during the upload process.

--- a/src/content/docs/ci/checks/upload-coverage.mdx
+++ b/src/content/docs/ci/checks/upload-coverage.mdx
@@ -10,4 +10,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-

--- a/src/content/docs/ci/faq.mdx
+++ b/src/content/docs/ci/faq.mdx
@@ -5,104 +5,11 @@ sidebar:
   order: 5
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-Still have a question about Shorebird CI that the docs didn’t cover? You’re in
-the right place. This page covers the most common questions. If you have a
-question not answered here or elsewhere in the docs, reach out on Discord or
-file an issue. The Shorebird team is happy to help.
-
-## Product overview
-
-### Why use this rather than another solution?
-
-- **Designed for Flutter & Dart** - With this as its leading principle,
-  Shorebird CI has support for Flutter & Dart specific features. This includes
-  automatic monorepo & workspace support, automatic parallelization across
-  multiple package builds, and caching for all critical tooling for fast
-  execution.
-- **Zero config** - Nothing to think about (or worry about keeping up to date).
-  Shorebird CI just “does the right thing” for Flutter and Dart projects.
-- **Fast** - On par with GitHub actions (with room to make it faster still).
-  Quick boot ups, uses similar (if slightly larger) machine instances, uses
-  namespace.so’s fancy caching mechanism, etc.
-
-:::note
-
-This is not currently designed to replace your existing release flow (e.g.
-CodeMagic, fastlane, etc.) but rather to supplement them.
-
-:::
-
-### How fast is it?
-
-Checks typically complete in under a minute even with large repos, including
-monorepos. This is mostly due to caching of Dart & Flutter and automatic
-parallelization of packages. Shorebird will continue to invest in this over time
-as usage grows and the community's needs around Dart-specific pipelines become
-clearer.
-
-### What checks are supported?
-
-Shorebird CI starts with a few key checks based on internal needs and what other
-open source repos are doing. The [Checks](/ci/checks/) documentation will
-continue to be kept up to date with what's currently available.
-
-If you have a specific check that you are looking for please don't hesitate to
-reach out — more checks are always being considered based on community needs.
-
-## GitHub Integration
-
-### What GitHub permissions does this require and why?
-
-In order to use Shorebird CI, its GitHub Application requires the following
-permissions
-
-- **Read access to code, metadata, and pull requests** - This allows the
-  application to check out your codebase and run the necessary checks. All code
-  is securely deleted after runs.
-- **Read and write access to checks, commit statuses, and workflows** - This
-  allows the application to report back on the status checks that are running
-  and display them in the GitHub UI.
-
-## Data privacy
-
-### Where do builds happen?
-
-Builds happen through Shorebird's partnership with namespace.so. Namespace uses
-several custom datacenters throughout the world and you can read more about this
-in their [Documentation Site](https://namespace.so/docs) and
-[Trust Center](https://trust.namespace.so).
-
-### What data do you retain?
-
-In order to provide a complete service, some of your data needs to be retained.
-
-- **Logs** - The only data intentionally retained is your build logs, which are
-  served from
-  [the CI section of the web console](https://console.shorebird.dev/ci/). Some
-  minimal metadata is also maintained to associate a pull request/commit with a
-  build log.
-  - Shorebird's build provider [Namespace](https://namespace.so) also retains
-    logs in accordance with their [Terms of Use](https://namespace.so/terms).
-- **Source Code** - A copy of your public source code is retained to speed up
-  repeated builds. There is not currently an explicit retention time on this.
-  Private repositories are currently under development and will have more
-  stringent requirements.
-
-### How to delete your data from the service?
-
-You need to start by [uninstalling the app on GitHub](/ci/uninstall). After this
-no additional information or data will be sent to Shorebird CI.
-
-Public log links are currently retained after an uninstall in order to not break
-links on existing PRs. If you require those to be deleted as well please reach
-out
-[via email](mailto:contact@shorebird.dev?subject=CI%20Data%20Delete%20Request)
-from the account owners address and it will be handled manually.

--- a/src/content/docs/ci/faq.mdx
+++ b/src/content/docs/ci/faq.mdx
@@ -12,4 +12,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-

--- a/src/content/docs/ci/index.mdx
+++ b/src/content/docs/ci/index.mdx
@@ -6,55 +6,11 @@ sidebar:
   order: 1
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-## What is Shorebird CI?
-
-Zero-config, production-grade continuous integration for Flutter & Dart.
-
-Shorebird CI automatically runs best practice Flutter & Dart checks on every
-pull request. The Shorebird team built it for themselves and uses it in all of
-Shorebird's repos, and now you can too.
-
-- ✨ Set up takes less than a minute
-- 🚀 Fast Checks
-- ✅ Production Ready
-- 💙 Built for Flutter & Dart
-
-<div style="display:flex;justify-content:center">
-  <iframe
-    style="aspect-ratio:16/9;width:100%;margin-inline:auto;margin-bottom:1em"
-    src="https://www.youtube.com/embed/ZMMV418Dt80?si=yIiBjNynHxrL_DpR"
-    title="YouTube video player"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-    referrerpolicy="strict-origin-when-cross-origin"
-    allowfullscreen
-  ></iframe>
-</div>
-
-## Requirements for use
-
-Shorebird CI will work on any repository that contains at least one Flutter or
-Dart project, including monorepos.
-
-## How does Shorebird CI work?
-
-When you install the
-[Shorebird CI GitHub app](https://github.com/apps/shorebird-ci) on a GitHub
-organization or repository, Shorebird CI is able to automatically run when a
-relevant GitHub event occurs (e.g., a push or pull request). Shorebird CI
-statically analyzes the repository to determine what checks need to be run and,
-within seconds, the relevant jobs are queued and executed in parallel.
-
-For most repositories, this will be a single package, and the job display name
-will be the name of the package (derived from the `pubspec.yaml`). You can click
-the job to view a summary, detailed logs, and overall results. Click
-`"View more details on Shorebird CI"` to see the full logs in the
-[Shorebird Console](https://console.shorebird.dev/ci).

--- a/src/content/docs/ci/index.mdx
+++ b/src/content/docs/ci/index.mdx
@@ -13,4 +13,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-

--- a/src/content/docs/ci/setup.mdx
+++ b/src/content/docs/ci/setup.mdx
@@ -14,5 +14,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-
-

--- a/src/content/docs/ci/setup.mdx
+++ b/src/content/docs/ci/setup.mdx
@@ -7,77 +7,12 @@ sidebar:
   order: 2
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-import { Image } from 'astro:assets';
-import ciConsoleNavigation from '~/assets/ci_console_navigation.png';
-import ciLoginWithGitHub from '~/assets/ci_login_with_github_screen.png';
-import ciSetupGitHubOrg from '~/assets/ci_setup_github_org.png';
-import ciGitHubInstall from '~/assets/ci_gh_install.png';
-import ciEnable from '~/assets/ci_enable.png';
-import ciEnabled from '~/assets/ci_enabled.png';
-import ciChecksPassing from '~/assets/ci_checks_passing.png';
 
-:::note
-
-Shorebird CI requires a "Pro" subscription in order to run checks on private
-repositories. Upgrade to the "Pro" CI plan from the
-[Web Console](https://console.shorebird.dev/ci).
-
-:::
-
-Configuring Shorebird CI takes less than a minute and requires zero code
-changes.
-
-1. From the [Web Console](https://console.shorebird.dev), select **CI** from the
-   navigation panel.
-   <Image
-     src={ciConsoleNavigation}
-     alt="Screenshot of the Shorebird Web Console showing the CI item in the navigation panel."
-   />
-2. Sign in with your GitHub account.
-   <Image
-     src={ciLoginWithGitHub}
-     alt="Screenshot of the Shorebird Web Console prompting the user to log in with their GitHub account."
-   />
-3. Install the Shorebird CI GitHub app on the desired GitHub
-   organizations/repositories.
-   <Image
-     src={ciSetupGitHubOrg}
-     alt="Screenshot of the Shorebird Web Console asking to install the Shorebird CI GitHub Application."
-   />
-4. Confirm the installation for the desired organizations/repositories.
-   <Image
-     src={ciGitHubInstall}
-     alt="Screenshot of the Shorebird CI GitHub Application install configuration."
-   />
-5. Refresh the [Web Console](https://console.shorebird.dev/ci) and enable the
-   Shorebird CI service for the desired GitHub organizations.
-   <Image
-     src={ciEnable}
-     alt="Screenshot of the Shorebird Web Console enabling the Shorebird CI service for a specific organization."
-   />
-   <Image
-     src={ciEnabled}
-     alt="Screenshot of the Shorebird Web Console showing the Shorebird CI service enabled for a specific organization."
-   />
-
-## Running Shorebird CI
-
-When you open a pull request or push a new commit to an existing pull request,
-Shorebird CI will automatically run for you. It will detect if there are any
-Dart or Flutter packages and automatically start running the available checks.
-
-<Image
-  src={ciChecksPassing}
-  alt="Screenshot of the Shorebird CI GitHub App checks passing during a pull request"
-/>
-
-To see more details from these checks, you can
-[view the logs for the run](/ci/view-logs/).

--- a/src/content/docs/ci/uninstall.mdx
+++ b/src/content/docs/ci/uninstall.mdx
@@ -5,37 +5,11 @@ sidebar:
   order: 4
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-import { Image } from 'astro:assets';
-import ciListInstalledGHApps from '~/assets/ci_list_installed_gh_apps.png';
-import ciGHAppSettings from '~/assets/ci_gh_app_settings.png';
-
-If you need to remove Shorebird CI from your workflow, you can follow the steps
-below.
-
-1. Go to your "Installed GitHub Apps" page for your repository.
-   - For installations at the organization-level, you can go to
-     https://github.com/organizations/ORG_NAME_HERE/settings/installations
-   - For personal or user-level installations, this can be done at
-     https://github.com/settings/installations
-2. Click **Configure**.
-
-   <Image
-     src={ciListInstalledGHApps}
-     alt="Screenshot of installed GitHub applications at an organization level"
-   />
-
-3. You can then restrict Shorebird CI to specific repositories, or uninstall the
-   app entirely.
-
-   <Image
-     src={ciGHAppSettings}
-     alt="Screenshot of the Shorebird CI GitHub Applications settings"
-   />

--- a/src/content/docs/ci/uninstall.mdx
+++ b/src/content/docs/ci/uninstall.mdx
@@ -12,4 +12,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-

--- a/src/content/docs/ci/view-logs.mdx
+++ b/src/content/docs/ci/view-logs.mdx
@@ -5,31 +5,12 @@ sidebar:
   order: 3
 ---
 
-:::caution[Shorebird CI has been shut down]
+:::caution[Shorebird CI has been deprecated]
 
-Shorebird CI was shut down on **August 8, 2026**. See the
+Shorebird CI was deprecated on **August 8, 2026**. See the
 [Shorebird CI README](https://github.com/shorebirdtech/shorebird/blob/main/packages/shorebird_ci/README.md)
 for migration options.
 
 :::
 
-import { Image } from 'astro:assets';
-import ciViewRunDetails from '~/assets/ci_view_run_details.png';
-import ciWebConsoleLogs from '~/assets/ci_web_console_logs.png';
 
-While Shorebird CI is executing, the details from the run will be automatically
-updated as steps run, succeed, or fail.
-
-<Image
-  src={ciViewRunDetails}
-  alt="Screenshot of the details of a Shorebird CI run"
-/>
-
-By clicking on the "View more details" button, you will be taken to the
-Shorebird CI web console. This web console allows you to see the detailed logs
-for each step in the run.
-
-<Image
-  src={ciWebConsoleLogs}
-  alt="Screenshot of the details of a Shorebird CI run via the Shorebird CI Web Console"
-/>

--- a/src/content/docs/ci/view-logs.mdx
+++ b/src/content/docs/ci/view-logs.mdx
@@ -12,5 +12,3 @@ Shorebird CI was deprecated on **August 8, 2026**. See the
 for migration options.
 
 :::
-
-


### PR DESCRIPTION
## Status

READY

## Description

Marks Shorebird CI as deprecated across all documentation.

### Changes

- Replaces the active Shorebird CI docs with a deprecation notice, directing users to standard CI solutions
- Removes or stubs out setup, checks, FAQ, uninstall, and view-logs pages since the product is no longer supported
- Cleans up all affected `.mdx` files to pass prettier formatting