### PR TITLE
fix(ci): follow vale-action to its new owner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: ✍️ Vale
-        uses: errata-ai/vale-action@v3
+        uses: vale-cli/vale-action@v3
         with:
           reporter: github-pr-check
           filter_mode: nofilter


### PR DESCRIPTION
Vale moved from `errata-ai` to `vale-cli`. The Actions runner stopped following repository-transfer redirects earlier today: `_shorebird`'s `e2e` job broke at 18:18 UTC with

```
Unable to resolve action. Repository not found: isbang/compose-action
```

on exactly this class of reference (fix: shorebirdtech/_shorebird#2923). This one is a latent break rather than a live one — the last `docs` CI run was 15:30 UTC, before the change — so it will fail on the next push unless renamed.

`vale-cli/vale-action@v3` and `errata-ai/vale-action@v3` resolve to the same commit (`518a913`), so this is a rename with no version change and no input changes.

Found by sweeping every `uses:` across the org's non-archived repos (506 references, 46 distinct third-party actions) and checking which owners no longer resolve directly. These two were the only real transfers; `reactivecircus/android-emulator-runner` differs only in letter case, which the runner handles.

https://claude.ai/code/session_01UWYSL7sjZsJAgLKh1Hmzyq