### PR TITLE
fix(ci): format astro.config.mjs with single quotes

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -124,10 +124,10 @@ export default defineConfig({
         starlightLlmsTxt({
           optionalLinks: [
             {
-              label: "OpenAPI specification",
-              url: "https://api.shorebird.dev/openapi.json",
+              label: 'OpenAPI specification',
+              url: 'https://api.shorebird.dev/openapi.json',
               description:
-                "Full OpenAPI 3.1 spec for the Shorebird Code Push API — endpoints, auth, and schemas",
+                'Full OpenAPI 3.1 spec for the Shorebird Code Push API — endpoints, auth, and schemas',
             },
           ],
         }),


### PR DESCRIPTION
`main` is red: the `build` job's ✨ Check Format step fails on `astro.config.mjs`.

The `optionalLinks` block added in #646 uses double quotes, and `.prettierrc` sets `singleQuote: true`. Prettier exits 1, so the ✨ Check Format step fails and 📦 Build Site never runs. #646's own PR check ([run 33887289390](https://github.com/shorebirdtech/docs/actions/runs/33887289390)) failed the same way before it merged.

This runs `prettier --write` on the three offending lines. No behavior change.

Verified locally on this branch:

- `npm run format:check` → `All matched files use Prettier code style!`
- `npm run build` → `72 page(s) built`, link validation passes
- `dist/llms.txt` carries the link #646 intended:

```
## Optional

- [OpenAPI specification](https://api.shorebird.dev/openapi.json): Full OpenAPI 3.1 spec for the Shorebird Code Push API — endpoints, auth, and schemas
```
