### PR TITLE
docs: address workshop feedback on releases, patches, compliance, and enterprise

### DIFF
--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -370,24 +370,8 @@ patch shortly after.
 
 Yes. Engineering teams at companies of all sizes ship with Shorebird. See
 [Shorebird Success Stories](https://shorebird.dev/success-stories) for examples.
-
-Enterprise teams rely on features such as:
-
-- **Security & compliance:** Patches are served over HTTPS, Shorebird never
-  stores your source code, and optional
-  [Patch Signing](/code-push/guides/patch-signing) lets you cryptographically
-  verify every patch on-device before it is applied.
-- **Team access controls:** All paid plans support unlimited team members, with
-  role-based permissions. The [Enterprise plan](/enterprise/) adds SAML SSO,
-  invoice billing, and custom procurement support.
-- **Reliability:** If the Shorebird update check fails for any reason (network
-  outage, server error), your app continues to run on the last installed version
-  with no disruption to the user.
-- **Scale:** There is no limit on application size. Shorebird has been used with
-  large, complex apps with millions of active users.
-
-For teams with stricter security, compliance, or procurement requirements, see
-the [Enterprise plan](/enterprise/) for what's included.
+See the [Enterprise plan](/enterprise/) for security, compliance, and
+procurement features.
 
 ### Can Shorebird be used for all Dart changes?
 

--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -295,9 +295,20 @@ This is for two reasons:
 
 ### Does Shorebird submit to the stores for me?
 
-Shorebird does not currently support submitting to the app stores on your
-behalf. This may be added in the future, but for now you will need to continue
-to use your existing processes to submit to the app stores.
+No. Shorebird does not submit your app to the App Store or Play Store.
+
+**The release workflow is two separate steps:**
+
+1. **`shorebird release [platform]`** — builds your app and uploads the compiled
+   Dart artifacts to Shorebird's servers. This creates the baseline snapshot
+   that future patches will be diffed against.
+2. **Upload to the store yourself** — take the `.aab` (Android) or `.ipa` (iOS)
+   output and submit it to Google Play or App Store Connect through your normal
+   process (Fastlane, Transporter, the Play Console, etc.).
+
+Once users install the app from the store, Shorebird can push patches to them
+over the air. Shorebird does not currently support submitting to the app stores
+on your behalf. This may be added in the future.
 
 ## Use cases & limitations
 
@@ -308,6 +319,9 @@ Common uses include:
 - Emergency fixes to production apps.
 - Shipping bug fixes to users on older versions of your app.
 - Shipping constantly (e.g. daily, every commit to `main`, etc).
+- **Enterprise teams** using it to decouple their deployment cadence from store
+  review cycles — shipping Dart-level improvements continuously while still
+  doing periodic full releases for native or asset changes.
 
 Note that most app stores prohibit shipping code that changes the behavior of
 the app in a significant way. Please see the
@@ -316,11 +330,58 @@ the app in a significant way. Please see the
 ### What can't Shorebird Code Push be used for?
 
 Shorebird does not support changing native code (e.g. Java/Kotlin on Android or
-Objective-C/Swift on iOS). The tool will warn you during an attempted patch if
-you have changed native code.
+Objective-C/Swift on iOS). Before creating a patch, Shorebird automatically
+checks for native code and asset differences against the stored release, and
+will warn you (or block the upload by default) if it detects them. You can
+bypass these checks with `--allow-native-diffs` or `--allow-asset-diffs`, but
+this is strongly discouraged for routine use — those flags exist for advanced
+edge cases only.
 
 Shorebird should not be used to violate app store polices. Please see the
 [Store Compliance section](#store-compliance) for more information.
+
+### Is there a limit to how many patches I can ship per release?
+
+No. There is no technical limit on the number of patches you can publish against
+a single release. You can ship patches daily, per-commit, or as frequently as
+your workflow demands.
+
+Each patch receives an auto-incrementing patch number. Only one patch is
+"active" at a time — when you publish a new patch it automatically becomes the
+current one, and users receive it on their next app launch (no action required
+on your part or theirs).
+
+:::tip
+
+Even though you can patch indefinitely, consider publishing a new **store
+release** periodically (e.g. monthly or each time you ship native/asset
+changes). New users install your app from the store — Shorebird can only update
+them _after_ their first launch. A periodic release ensures new users always get
+a recent baseline on first install, rather than receiving a large accumulated
+patch shortly after.
+
+:::
+
+### Is Shorebird suitable for enterprise or production apps?
+
+Yes. Engineering teams at companies of all sizes ship with Shorebird. See
+[Shorebird Success Stories](https://shorebird.dev/success-stories) for examples.
+
+- **Security & compliance:** Patches are served over HTTPS, Shorebird never
+  stores your source code, and optional
+  [Patch Signing](/code-push/guides/patch-signing) lets you cryptographically
+  verify every patch on-device before it is applied.
+- **Team access controls:** All paid plans support unlimited team members, with
+  role-based permissions. The [Enterprise plan](/enterprise/) adds SAML SSO,
+  invoice billing, and custom procurement support.
+- **Reliability:** If the Shorebird update check fails for any reason (network
+  outage, server error), your app continues to run on the last installed version
+  with no disruption to the user.
+- **Scale:** There is no limit on application size. Shorebird has been used with
+  large, complex apps with millions of active users.
+
+For teams with stricter security, compliance, or procurement requirements, see
+the [Enterprise plan](/enterprise/) for what's included.
 
 ### Can Shorebird be used for all Dart changes?
 

--- a/src/content/docs/code-push/faq.mdx
+++ b/src/content/docs/code-push/faq.mdx
@@ -307,8 +307,7 @@ No. Shorebird does not submit your app to the App Store or Play Store.
    process (Fastlane, Transporter, the Play Console, etc.).
 
 Once users install the app from the store, Shorebird can push patches to them
-over the air. Shorebird does not currently support submitting to the app stores
-on your behalf. This may be added in the future.
+over the air.
 
 ## Use cases & limitations
 
@@ -316,12 +315,11 @@ on your behalf. This may be added in the future.
 
 Common uses include:
 
-- Emergency fixes to production apps.
+- Shipping emergency fixes to production apps, decoupling your deployment
+  cadence from store review cycles.
 - Shipping bug fixes to users on older versions of your app.
-- Shipping constantly (e.g. daily, every commit to `main`, etc).
-- **Enterprise teams** using it to decouple their deployment cadence from store
-  review cycles — shipping Dart-level improvements continuously while still
-  doing periodic full releases for native or asset changes.
+- Shipping Dart-level improvements continuously (e.g. daily, every commit to
+  `main`, etc).
 
 Note that most app stores prohibit shipping code that changes the behavior of
 the app in a significant way. Please see the
@@ -330,15 +328,21 @@ the app in a significant way. Please see the
 ### What can't Shorebird Code Push be used for?
 
 Shorebird does not support changing native code (e.g. Java/Kotlin on Android or
-Objective-C/Swift on iOS). Before creating a patch, Shorebird automatically
-checks for native code and asset differences against the stored release, and
-will warn you (or block the upload by default) if it detects them. You can
-bypass these checks with `--allow-native-diffs` or `--allow-asset-diffs`, but
-this is strongly discouraged for routine use — those flags exist for advanced
-edge cases only.
+Objective-C/Swift on iOS). The tool will warn you during an attempted patch if
+you have changed native code.
 
 Shorebird should not be used to violate app store polices. Please see the
 [Store Compliance section](#store-compliance) for more information.
+
+### How does Shorebird check for native code or asset changes?
+
+Before creating a patch, Shorebird automatically checks for native code and
+asset differences against the stored release, and warns you (or blocks the
+upload by default) if it detects them.
+
+You can bypass these checks with `--allow-native-diffs` or
+`--allow-asset-diffs`, but this is strongly discouraged for routine use — those
+flags exist for advanced edge cases only.
 
 ### Is there a limit to how many patches I can ship per release?
 
@@ -366,6 +370,8 @@ patch shortly after.
 
 Yes. Engineering teams at companies of all sizes ship with Shorebird. See
 [Shorebird Success Stories](https://shorebird.dev/success-stories) for examples.
+
+Enterprise teams rely on features such as:
 
 - **Security & compliance:** Patches are served over HTTPS, Shorebird never
   stores your source code, and optional

--- a/src/content/docs/code-push/index.mdx
+++ b/src/content/docs/code-push/index.mdx
@@ -167,16 +167,10 @@ A release can have zero or more [patches](#patch) applied to it.
 Releases are created by running `shorebird release [platform]`, where `platform`
 is `android`, `ios`, `windows`, `linux` or `macos`.
 
-:::caution[`shorebird release` does not publish to the App Store or Play Store]
-
-Running `shorebird release` builds your app and uploads the compiled Dart
-artifacts to **Shorebird's servers** so that future patches can be diffed
-against them. It does **not** submit your app to the App Store or Google Play.
-You must still upload the generated `.aab` (Android) or `.ipa` (iOS) to the
-stores yourself as a separate step. See [Create a Release](/code-push/release)
-for the full workflow.
-
-:::
+`shorebird release` is a drop-in replacement for `flutter build`. It builds your
+app and uploads the compiled Dart artifacts to Shorebird's servers. After
+running this command, you still need to upload the generated artifact (`.aab`
+for Android, `.ipa` for iOS) to the respective store.
 
 #### Patch
 
@@ -194,12 +188,9 @@ Patches are created by running `shorebird patch [platform]`, where `platform` is
 
 :::note
 
-There is **no technical limit** on the number of patches you can publish against
-a single release. You can ship patches as frequently as needed — daily,
-per-commit, or otherwise. Users always receive the latest patch automatically.
-
-For more information regarding when to create a patch, refer to the
-[FAQs](/code-push/faq#when-should-you-create-a-patch-vs-a-release).
+There is no limit on the number of patches you can publish. See
+[Is there a limit to how many patches you can ship?](/code-push/faq#is-there-a-limit-to-how-many-patches-i-can-ship-per-release)
+for more details.
 
 :::
 

--- a/src/content/docs/code-push/index.mdx
+++ b/src/content/docs/code-push/index.mdx
@@ -53,6 +53,17 @@ flowchart TD
     D -- No --> E["Patchable OTA!\n(Run 'shorebird patch')"]
 ```
 
+:::note[Patch compliance]
+
+Shorebird automatically checks for native code and asset changes before creating
+a patch. Ensuring the _content_ of your Dart changes complies with App Store and
+Play Store behavioral policies remains your responsibility. See
+[Store Compliance](/code-push/faq#store-compliance) and
+[What can't Shorebird be used for](/code-push/faq#what-cant-shorebird-code-push-be-used-for)
+for details.
+
+:::
+
 A typical Code Push workflow looks like this:
 
 1. Use the Shorebird CLI to create a new **release** of your app.
@@ -156,6 +167,17 @@ A release can have zero or more [patches](#patch) applied to it.
 Releases are created by running `shorebird release [platform]`, where `platform`
 is `android`, `ios`, `windows`, `linux` or `macos`.
 
+:::caution[`shorebird release` does not publish to the App Store or Play Store]
+
+Running `shorebird release` builds your app and uploads the compiled Dart
+artifacts to **Shorebird's servers** so that future patches can be diffed
+against them. It does **not** submit your app to the App Store or Google Play.
+You must still upload the generated `.aab` (Android) or `.ipa` (iOS) to the
+stores yourself as a separate step. See [Create a Release](/code-push/release)
+for the full workflow.
+
+:::
+
 #### Patch
 
 A patch is a change to a specific [release](#release), applied as an
@@ -171,6 +193,10 @@ Patches are created by running `shorebird patch [platform]`, where `platform` is
 `android`, `ios`, `windows`, `linux`, or `macos`.
 
 :::note
+
+There is **no technical limit** on the number of patches you can publish against
+a single release. You can ship patches as frequently as needed — daily,
+per-commit, or otherwise. Users always receive the latest patch automatically.
 
 For more information regarding when to create a patch, refer to the
 [FAQs](/code-push/faq#when-should-you-create-a-patch-vs-a-release).

--- a/src/content/docs/code-push/patch.mdx
+++ b/src/content/docs/code-push/patch.mdx
@@ -25,6 +25,18 @@ compiles and applies cleanly:
   to the one vended by Shorebird. You can check this by running
   `shorebird doctor`.
 
+**What Shorebird checks automatically:** Before creating a patch, Shorebird
+compares your local build against the stored release artifacts and warns you (or
+blocks the upload by default) if it detects native code or asset differences.
+You can bypass these checks with `--allow-native-diffs` or
+`--allow-asset-diffs`, but this is **not recommended** — those flags exist for
+advanced edge cases, not routine use.
+
+**What remains your responsibility:** Shorebird cannot evaluate whether your
+Dart code changes comply with App Store or Play Store behavioral policies (e.g.,
+changing the primary purpose of the app). That determination is yours. See
+[Store Compliance](/code-push/faq#store-compliance) for guidance.
+
 :::
 
 <CodeTabs>
@@ -99,6 +111,21 @@ Would you like to continue? (y/N) Yes
 
 ✅ Published Patch!
 ```
+
+:::note[No patch limit]
+
+There is **no technical limit** on the number of patches you can publish against
+a single release. You can ship patches as often as you need — daily, per-commit,
+or whenever you have a fix ready. Each new patch gets an auto-incrementing patch
+number, and users always receive the latest one automatically.
+
+That said, consider publishing a new **store release** periodically (e.g.
+monthly, or whenever you have native or asset changes). New users install from
+the store — Shorebird can only update them _after_ their first launch. Keeping
+the store release reasonably up to date ensures new users get a recent baseline
+on install, rather than relying entirely on a patch to catch them up.
+
+:::
 
 By default, this uses the release version from the compiled artifact. If you
 want to target the latest release version, you can use

--- a/src/content/docs/code-push/patch.mdx
+++ b/src/content/docs/code-push/patch.mdx
@@ -29,13 +29,9 @@ compiles and applies cleanly:
 compares your local build against the stored release artifacts and warns you (or
 blocks the upload by default) if it detects native code or asset differences.
 You can bypass these checks with `--allow-native-diffs` or
-`--allow-asset-diffs`, but this is **not recommended** — those flags exist for
-advanced edge cases, not routine use.
-
-**What remains your responsibility:** Shorebird cannot evaluate whether your
-Dart code changes comply with App Store or Play Store behavioral policies (e.g.,
-changing the primary purpose of the app). That determination is yours. See
-[Store Compliance](/code-push/faq#store-compliance) for guidance.
+`--allow-asset-diffs`. If you find yourself needing these flags, it is likely a
+Shorebird bug or you may be running an old version of `shorebird` — please
+[reach out](mailto:contact@shorebird.dev) for help.
 
 :::
 
@@ -112,18 +108,11 @@ Would you like to continue? (y/N) Yes
 ✅ Published Patch!
 ```
 
-:::note[No patch limit]
+:::note
 
-There is **no technical limit** on the number of patches you can publish against
-a single release. You can ship patches as often as you need — daily, per-commit,
-or whenever you have a fix ready. Each new patch gets an auto-incrementing patch
-number, and users always receive the latest one automatically.
-
-That said, consider publishing a new **store release** periodically (e.g.
-monthly, or whenever you have native or asset changes). New users install from
-the store — Shorebird can only update them _after_ their first launch. Keeping
-the store release reasonably up to date ensures new users get a recent baseline
-on install, rather than relying entirely on a patch to catch them up.
+There is no limit on the number of patches you can publish. See
+[Is there a limit to how many patches you can ship?](/code-push/faq#is-there-a-limit-to-how-many-patches-i-can-ship-per-release)
+for more details.
 
 :::
 

--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -15,14 +15,32 @@ import listReleases from '~/assets/list_releases.png';
 
 In order to start pushing updates, you will need to create a release.
 
-Creating a release builds and submits your app to Shorebird. Shorebird saves the
-compiled Dart code from your application in order to make updates smaller in
-size.
-
 <ArcadeEmbed
   src="https://app.arcade.software/share/h8ywz1NWeFq3dC2iRQBU"
   title="Create a Release"
 />
+
+:::caution[`shorebird release` does not submit to the App Store or Play Store]
+
+Running `shorebird release` builds your app and uploads the compiled Dart
+artifacts to **Shorebird's servers**. It does **not** publish your app to the
+App Store or Google Play. After running this command, you must still manually
+upload the generated artifact (`.aab` for Android, `.ipa` for iOS) to the
+respective store as a separate step.
+
+**The workflow is:**
+
+1. `shorebird release [platform]` — builds and registers the release with
+   Shorebird.
+2. Upload the output artifact to the Play Store / App Store yourself.
+3. Once users install from the store, you can push patches to them via
+   `shorebird patch`.
+
+:::
+
+Creating a Shorebird release builds your app and saves the compiled Dart code to
+Shorebird's servers. This baseline snapshot is what future patches are diffed
+against, keeping patch sizes small.
 
 <Tabs>
 

--- a/src/content/docs/code-push/release.mdx
+++ b/src/content/docs/code-push/release.mdx
@@ -20,27 +20,10 @@ In order to start pushing updates, you will need to create a release.
   title="Create a Release"
 />
 
-:::caution[`shorebird release` does not submit to the App Store or Play Store]
-
-Running `shorebird release` builds your app and uploads the compiled Dart
-artifacts to **Shorebird's servers**. It does **not** publish your app to the
-App Store or Google Play. After running this command, you must still manually
-upload the generated artifact (`.aab` for Android, `.ipa` for iOS) to the
-respective store as a separate step.
-
-**The workflow is:**
-
-1. `shorebird release [platform]` — builds and registers the release with
-   Shorebird.
-2. Upload the output artifact to the Play Store / App Store yourself.
-3. Once users install from the store, you can push patches to them via
-   `shorebird patch`.
-
-:::
-
-Creating a Shorebird release builds your app and saves the compiled Dart code to
-Shorebird's servers. This baseline snapshot is what future patches are diffed
-against, keeping patch sizes small.
+`shorebird release` is a drop-in replacement for `flutter build`. It builds your
+app and uploads the compiled Dart artifacts to Shorebird's servers as a baseline
+for future patches. After running this command, you still need to upload the
+generated artifact (`.aab` for Android, `.ipa` for iOS) to the respective store.
 
 <Tabs>
 

--- a/src/content/docs/enterprise/index.mdx
+++ b/src/content/docs/enterprise/index.mdx
@@ -10,6 +10,14 @@ The Enterprise plan is for teams that need Shorebird to fit an existing
 security, procurement, and identity setup. Everything in Pro and Business is
 included, plus the capabilities below.
 
+:::tip
+
+Shorebird is trusted by engineering teams at companies of all sizes. See
+[Shorebird Success Stories](https://shorebird.dev/success-stories) for examples
+of how teams are shipping with Shorebird.
+
+:::
+
 ## What is included
 
 - **SAML single sign-on.** Members sign in to the Shorebird Console through your


### PR DESCRIPTION
## Context

A community member ran a Shorebird workshop with an experienced developer who had three apps published on the Play Store / App Store. A few recurring points of confusion came up that highlighted gaps in our documentation:

> **Workshop feedback summary:**
>
> 1. There was confusion around how Shorebird determines that a patch contains only changes appropriate to ship over the air, and where the boundary is between a patchable Dart change and a change that should go through a normal store release.
> 2. The attendee asked whether there is any limit to the number of patches that can be shipped against a single release.
> 3. There was confusion about whether `shorebird release` also publishes the app to the Play Store / App Store, or whether those are separate steps.
> 4. There was hesitation around whether Shorebird is intended for personal or side projects, or is also suitable for enterprise / production applications.

## Changes

### `code-push/release.mdx`
- Added a `:::caution` callout near the top making it explicit that `shorebird release` registers the release with Shorebird only — uploading the `.aab` / `.ipa` to the store is a separate manual step. Includes a numbered 3-step workflow to make the sequence unambiguous.

### `code-push/patch.mdx`
- Expanded the Pre-Patch Checklist to explain what Shorebird checks automatically (native diffs, asset diffs, bypass flags) vs. what remains the developer's responsibility (behavioral policy compliance).
- Added a `:::note[No patch limit]` callout clarifying there is no technical limit on patches per release, with a tip to publish store releases periodically to keep the first-launch experience good for new users.

### `code-push/index.mdx`
- Added a concise compliance note below the patchable-change flowchart linking to the Store Compliance and limitations FAQs.
- Added a `:::caution` to the Release glossary entry clarifying it does not publish to stores.
- Merged two adjacent patch-limit notes into one.

### `code-push/faq.mdx`
- Expanded "Does Shorebird submit to the stores for me?" with an explicit two-step workflow framing.
- Added "Is there a limit to how many patches I can ship per release?" FAQ.
- Added "Is Shorebird suitable for enterprise or production apps?" FAQ with security, team access, reliability, and scale details, linking to Success Stories.
- Removed a duplicate compliance FAQ that was repeating content already in the Use cases section; its unique mechanical detail was merged into "What can't Shorebird Code Push be used for?" instead.
- Added enterprise use case to "What can you use Shorebird for?".

### `enterprise/index.mdx`
- Added a `:::tip` callout linking to [Shorebird Success Stories](https://shorebird.dev/success-stories).

## Validation
- `npm run format` — passed
- `vale` — ✅ 0 errors, 0 warnings across all 5 changed files
