### PR TITLE
feat: serve docs from Cloudflare Pages

### DIFF
--- a/.github/actions/astro_site/action.yaml
+++ b/.github/actions/astro_site/action.yaml
@@ -30,7 +30,6 @@ runs:
       working-directory: ${{ inputs.working_directory }}
 
     - name: 📦 Build Site
-      uses: withastro/action@v5
-      with:
-        path: ${{ inputs.working_directory }}
-        node-version: ${{ inputs.node_version }}
+      run: npm run build
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -29,26 +27,16 @@ jobs:
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
 
-  deploy:
-    needs: build
-
-    # Deploying on macos because pagefind cannot be installed on ubuntu-latest.
-    # https://github.com/CloudCannon/pagefind/issues/574
-    runs-on: macos-latest
-
-    if:
-      ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'schedule' || github.event_name ==
-      'workflow_dispatch' }}
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: 🚀 Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: 🚀 Deploy to Cloudflare Pages
+        if:
+          ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main')
+          || github.event_name == 'schedule' || github.event_name ==
+          'workflow_dispatch' }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name shorebird-docs --branch main
 
   spell-check:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-docs.shorebird.dev

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,10 @@
+# Agents fetch the .md alongside each page. GitHub Pages could not set these.
+/*.md
+  Content-Type: text/markdown; charset=utf-8
+  Access-Control-Allow-Origin: *
+
+/llms.txt
+  Access-Control-Allow-Origin: *
+
+/llms-full.txt
+  Access-Control-Allow-Origin: *

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "shorebird-docs",
+  "compatibility_date": "2026-09-08",
+  "pages_build_output_dir": "./dist",
+}


### PR DESCRIPTION
## Why

GitHub Pages cannot set response headers. That blocks serving markdown to agents with a `text/markdown` content type and CORS, which is the reason for the move. It also opens the door to per-PR preview deployments, which GHP cannot do at all.

Hosting lands in a Cloudflare account that holds only this site, separate from the account running the production caching worker on shorebird.cloud.

## What changes

- `wrangler.jsonc` points Pages at the existing Astro `dist` output. No build changes.
- `public/_headers` sets `text/markdown; charset=utf-8` and CORS on `.md`, plus CORS on the `llms.txt` files.
- The composite action builds with `npm run build` instead of `withastro/action@v5`, which was building *and* uploading the GitHub Pages artifact.
- The deploy job folds into `build`, so `dist` needs no artifact plumbing between jobs. Still on `macos-latest` for the pagefind constraint.
- `public/CNAME` is deleted, and `pages: write` / `id-token: write` are dropped from the workflow.

## Verified

Built and deployed by hand to the project this PR targets: **https://shorebird-docs-cz2.pages.dev**

- Pages render, including `/getting-started/`
- pagefind search index is present and served
- `llms.txt` returns `text/plain; charset=utf-8` with `access-control-allow-origin: *`

The `/*.md` content type rule is untestable today because the build emits no per-page markdown yet. Producing those files is separate work.

Cloudflare Pages already sets `access-control-allow-origin: *` on every asset by default, so the CORS lines in `_headers` are belt and braces. The content type line is the one doing real work.

## Sequencing, please read before merging

DNS is unchanged by this PR. `docs.shorebird.dev` still resolves to GitHub Pages.

Merging this stops GitHub Pages deploys, so the live site freezes at its last build until the DNS swap lands. It stays up, it just stops updating. Either merge immediately before the DNS change, or accept a stale window.

The DNS change is a one line edit to the `docs` record in shorebirdtech/_shorebird#2953, swapping `shorebirdtech.github.io.` for the Pages hostname, and it has to wait for that PR to merge and apply first.

## Also needed before this is durable

The `CLOUDFLARE_API_TOKEN` secret currently holds a token that expires in 7 days. It needs replacing with a non-expiring account-owned token, or deploys break a week from now.

## Follow-ups, not here

- Emit a `.md` for every page, which is the actual agent-facing feature
- Per-PR preview deployments
- Add the `docs.shorebird.dev` custom domain to the Pages project

https://claude.ai/code/session_012Pz9yRwJv9oFW3UZ4XrEfo