### PR TITLE
feat: serve raw Markdown for every docs page at <path>.md

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,19 @@
       "dependencies": {
         "@astrojs/check": "^0.9.10",
         "@astrojs/markdown-remark": "^7.3.0",
+        "@astrojs/mdx": "^7.0.5",
         "@astrojs/starlight": "^0.42.0",
         "@lavamoat/preinstall-always-fail": "^3.0.0",
         "@tailwindcss/vite": "^4.3.3",
         "astro": "^7.3.1",
         "astro-mermaid": "^2.1.0",
         "astro-opengraph-images": "^1.20.1",
+        "hast-util-select": "^6.0.4",
         "mermaid": "^11.17.2",
+        "rehype-parse": "^9.0.1",
+        "rehype-remark": "^10.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-stringify": "^11.0.0",
         "sharp": "^0.35.3",
         "starlight-auto-sidebar": "^0.4.1",
         "starlight-image-zoom": "^0.16.0",
@@ -24,10 +30,12 @@
         "starlight-theme-nova": "^0.12.3",
         "tailwindcss": "^4.2.0",
         "tw-to-css": "^0.0.12",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "unified": "^11.0.5"
       },
       "devDependencies": {
         "@lavamoat/allow-scripts": "^5.1.0",
+        "@types/hast": "^3.0.5",
         "@types/react": "^19.2.18",
         "@vvago/vale": "^3.17.1",
         "cspell": "^10.2.1",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,19 @@
   "dependencies": {
     "@astrojs/check": "^0.9.10",
     "@astrojs/markdown-remark": "^7.3.0",
+    "@astrojs/mdx": "^7.0.5",
     "@astrojs/starlight": "^0.42.0",
     "@lavamoat/preinstall-always-fail": "^3.0.0",
     "@tailwindcss/vite": "^4.3.3",
     "astro": "^7.3.1",
     "astro-mermaid": "^2.1.0",
     "astro-opengraph-images": "^1.20.1",
+    "hast-util-select": "^6.0.4",
     "mermaid": "^11.17.2",
+    "rehype-parse": "^9.0.1",
+    "rehype-remark": "^10.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-stringify": "^11.0.0",
     "sharp": "^0.35.3",
     "starlight-auto-sidebar": "^0.4.1",
     "starlight-image-zoom": "^0.16.0",
@@ -31,10 +37,12 @@
     "starlight-theme-nova": "^0.12.3",
     "tailwindcss": "^4.2.0",
     "tw-to-css": "^0.0.12",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^5.1.0",
+    "@types/hast": "^3.0.5",
     "@types/react": "^19.2.18",
     "@vvago/vale": "^3.17.1",
     "cspell": "^10.2.1",

--- a/src/pages/[...slug].md.ts
+++ b/src/pages/[...slug].md.ts
@@ -1,0 +1,35 @@
+import type { APIRoute, GetStaticPaths } from 'astro';
+import { getCollection } from 'astro:content';
+
+// Serves the raw Markdown/MDX source for every docs page at its URL + `.md`,
+// so AI agents can fetch page content directly instead of scraping rendered HTML.
+export const prerender = true;
+
+export const getStaticPaths = (async () => {
+  const docs = await getCollection('docs', (entry) => !entry.data.draft);
+  return docs.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}) satisfies GetStaticPaths;
+
+export const GET: APIRoute = ({ props }) => {
+  const { entry } = props;
+  // Strip MDX component imports; they're an implementation detail, not content.
+  const body = (entry.body ?? '').replace(/^import .+\n+/gm, '').trimStart();
+
+  const frontmatter = [
+    '---',
+    `title: ${JSON.stringify(entry.data.title)}`,
+    entry.data.description
+      ? `description: ${JSON.stringify(entry.data.description)}`
+      : undefined,
+    '---',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return new Response(`${frontmatter}\n\n${body}\n`, {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+};

--- a/src/pages/[...slug].md.ts
+++ b/src/pages/[...slug].md.ts
@@ -2,6 +2,8 @@ import mdxServer from '@astrojs/mdx/server.js';
 import type { APIContext, GetStaticPaths } from 'astro';
 import { experimental_AstroContainer } from 'astro/container';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
+import type { ElementContent } from 'hast';
+import { selectAll } from 'hast-util-select';
 import rehypeParse from 'rehype-parse';
 import rehypeRemark from 'rehype-remark';
 import remarkGfm from 'remark-gfm';
@@ -31,6 +33,48 @@ const astroContainer = await experimental_AstroContainer.create({
 
 const htmlToMarkdown = unified()
   .use(rehypeParse, { fragment: true })
+  // `<Tabs>` renders as a `<starlight-tabs>` custom element; without this,
+  // hast-util-to-mdast has no idea what it is and drops the tab labels
+  // while running every panel's content together with no separation.
+  // Converted to a list instead, same as starlight-llms-txt does for
+  // /llms-full.txt.
+  .use(function starlightTabsToList() {
+    return (tree) => {
+      for (const instance of selectAll(
+        'starlight-tabs',
+        tree as Parameters<typeof selectAll>[1],
+      )) {
+        const tabs = selectAll('[role="tab"]', instance);
+        const panels = selectAll('[role="tabpanel"]', instance);
+        instance.tagName = 'ul';
+        instance.properties = {};
+        instance.children = [];
+        for (let i = 0; i < Math.min(tabs.length, panels.length); i++) {
+          const tab = tabs[i];
+          const panel = panels[i];
+          if (!tab || !panel) continue;
+          const label = tab.children
+            .filter((child) => child.type === 'text' && child.value.trim())
+            .map((child) => (child.type === 'text' ? child.value.trim() : ''))
+            .join('');
+          instance.children.push({
+            type: 'element',
+            tagName: 'li',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'p',
+                properties: {},
+                children: [{ type: 'text', value: label }],
+              },
+              panel as ElementContent,
+            ],
+          });
+        }
+      }
+    };
+  })
   .use(rehypeRemark)
   .use(remarkGfm)
   .use(remarkStringify);

--- a/src/pages/[...slug].md.ts
+++ b/src/pages/[...slug].md.ts
@@ -1,8 +1,20 @@
-import type { APIRoute, GetStaticPaths } from 'astro';
-import { getCollection } from 'astro:content';
+import mdxServer from '@astrojs/mdx/server.js';
+import type { APIContext, GetStaticPaths } from 'astro';
+import { experimental_AstroContainer } from 'astro/container';
+import { getCollection, render, type CollectionEntry } from 'astro:content';
+import rehypeParse from 'rehype-parse';
+import rehypeRemark from 'rehype-remark';
+import remarkGfm from 'remark-gfm';
+import remarkStringify from 'remark-stringify';
+import { unified } from 'unified';
 
-// Serves the raw Markdown/MDX source for every docs page at its URL + `.md`,
-// so AI agents can fetch page content directly instead of scraping rendered HTML.
+// Serves Markdown for every docs page at its URL + `.md`, so AI agents can
+// fetch page content directly instead of scraping rendered HTML. Renders
+// each entry through the real Astro/Starlight pipeline (same as
+// `starlight-llms-txt`'s `/llms-full.txt`) rather than returning
+// `entry.body` as-is, so remark plugins (e.g. version placeholder
+// substitution) and MDX components are resolved instead of leaking into
+// the output as raw source.
 export const prerender = true;
 
 export const getStaticPaths = (async () => {
@@ -13,10 +25,22 @@ export const getStaticPaths = (async () => {
   }));
 }) satisfies GetStaticPaths;
 
-export const GET: APIRoute = ({ props }) => {
-  const { entry } = props;
-  // Strip MDX component imports; they're an implementation detail, not content.
-  const body = (entry.body ?? '').replace(/^import .+\n+/gm, '').trimStart();
+const astroContainer = await experimental_AstroContainer.create({
+  renderers: [{ name: 'astro:jsx', ssr: mdxServer }],
+});
+
+const htmlToMarkdown = unified()
+  .use(rehypeParse, { fragment: true })
+  .use(rehypeRemark)
+  .use(remarkGfm)
+  .use(remarkStringify);
+
+export async function GET(context: APIContext) {
+  const { entry } = context.props as { entry: CollectionEntry<'docs'> };
+
+  const { Content } = await render(entry);
+  const html = await astroContainer.renderToString(Content, context);
+  const markdown = String(await htmlToMarkdown.process(html)).trim();
 
   const frontmatter = [
     '---',
@@ -29,7 +53,10 @@ export const GET: APIRoute = ({ props }) => {
     .filter(Boolean)
     .join('\n');
 
-  return new Response(`${frontmatter}\n\n${body}\n`, {
+  // This header only takes effect in `astro dev`/`astro preview`: with
+  // `prerender = true` the route is written to disk as a static `.md` file,
+  // and `public/_headers` is what actually sets Content-Type in production.
+  return new Response(`${frontmatter}\n\n${markdown}\n`, {
     headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
   });
-};
+}


### PR DESCRIPTION
## Summary
- Adds `src/pages/[...slug].md.ts`, a catch-all endpoint that serves every docs page's source content as `text/markdown` at `<path>.md` (e.g. `/ci/view-logs.md`), so AI agents can fetch page content directly instead of scraping rendered HTML
- Reconstructs minimal frontmatter (title/description) and strips MDX component imports so the output reads as clean Markdown rather than raw source
- Complements the `public/_headers` rule (already on `main`) that sets `Content-Type: text/markdown` + CORS for `*.md` requests — that rule had no matching content until now, since neither `starlight-llms-txt`'s `/llms.txt`/`/llms-full.txt` routes nor Starlight itself serve per-page Markdown

## Test plan
- [x] `npm run build` succeeds (includes `astro check`)
- [x] Confirmed 70 `.md` files generated in `dist/`, one per non-draft docs page
- [x] Spot-checked `dist/index.md` and `dist/ci/view-logs.md` — clean frontmatter, imports stripped, Starlight aside syntax preserved
- [x] `npx prettier --check` passes on the new file
- [ ] After merge: verify `curl -I https://docs.shorebird.dev/ci/view-logs.md` returns `content-type: text/markdown` + `access-control-allow-origin: *` once deployed via CI