### PR TITLE
feat: content-negotiate Markdown for AI agents on canonical URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ dist/
 # generated types
 .astro/
 
+# local wrangler dev state
+.wrangler/
+
 # dependencies
 node_modules/
 

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,131 @@
+/// <reference types="@cloudflare/workers-types" />
+
+// Content negotiation for AI agents: a request for a normal docs URL with
+// `Accept: text/markdown` gets that page's Markdown sibling instead of HTML,
+// on the same URL a person would visit. The `.md` URLs themselves (added in
+// #654) keep working unchanged — this adds the "ask the canonical URL for
+// Markdown" path on top, which is what agent-friendliness scanners check for.
+//
+// Cloudflare's dashboard-level "Markdown for Agents" (AI Crawl Control) does
+// the same thing, but only for a zone on Cloudflare DNS with a Pro/Business
+// plan — shorebird.dev isn't (DNS lives elsewhere, just CNAMed to Pages), so
+// this reimplements the negotiation ourselves. Recipe:
+// https://acceptmarkdown.com/recipes/cloudflare-workers
+
+interface Env {
+  ASSETS: Fetcher;
+}
+
+// Static assets and non-content routes never have a Markdown sibling; skip
+// negotiation for them entirely.
+const SKIP_PATTERN =
+  /\.(css|js|mjs|json|png|jpe?g|gif|svg|webp|avif|ico|woff2?|ttf|eot|pdf|xml|txt|map)$/i;
+
+function markdownSiblingPath(pathname: string): string {
+  const trimmed =
+    pathname.endsWith('/') && pathname !== '/'
+      ? pathname.slice(0, -1)
+      : pathname;
+  return trimmed === '/' ? '/index.md' : `${trimmed}.md`;
+}
+
+interface AcceptEntry {
+  type: string;
+  q: number;
+  specificity: 0 | 1 | 2;
+}
+
+function parseAccept(header: string): AcceptEntry[] {
+  return header
+    .split(',')
+    .map((part): AcceptEntry | null => {
+      const [rawType, ...params] = part.trim().split(';');
+      const type = rawType?.trim().toLowerCase();
+      if (!type) return null;
+      let q = 1;
+      for (const param of params) {
+        const [key, value] = param.trim().split('=');
+        if (key === 'q' && value) q = Number.parseFloat(value) || 0;
+      }
+      const specificity = type === '*/*' ? 0 : type.endsWith('/*') ? 1 : 2;
+      return { type, q, specificity };
+    })
+    .filter((entry): entry is AcceptEntry => entry !== null);
+}
+
+// Highest (q * 10 + specificity) among entries matching `target`, or -1 if
+// nothing in the header would accept it.
+function scoreFor(entries: AcceptEntry[], target: string): number {
+  const group = `${target.split('/')[0]}/*`;
+  let best = -1;
+  for (const entry of entries) {
+    const matches =
+      entry.type === target || entry.type === '*/*' || entry.type === group;
+    if (matches && entry.q > 0)
+      best = Math.max(best, entry.q * 10 + entry.specificity);
+  }
+  return best;
+}
+
+type Preference = 'markdown' | 'html' | 'either' | 'none';
+
+function negotiate(acceptHeader: string | null): Preference {
+  if (!acceptHeader) return 'either';
+  const entries = parseAccept(acceptHeader);
+  const markdown = scoreFor(entries, 'text/markdown');
+  const html = scoreFor(entries, 'text/html');
+
+  if (markdown < 0 && html < 0) {
+    const rejectsEverything = entries.some(
+      (e) => e.type === '*/*' && e.q === 0,
+    );
+    return rejectsEverything ? 'none' : 'either';
+  }
+  if (markdown > html) return 'markdown';
+  if (html > markdown) return 'html';
+  return 'either';
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const { request } = context;
+  const url = new URL(request.url);
+
+  if (
+    (request.method !== 'GET' && request.method !== 'HEAD') ||
+    SKIP_PATTERN.test(url.pathname) ||
+    url.pathname.endsWith('.md')
+  ) {
+    return context.next();
+  }
+
+  const preference = negotiate(request.headers.get('Accept'));
+
+  if (preference === 'none') {
+    return new Response('Not Acceptable', {
+      status: 406,
+      headers: { Vary: 'Accept' },
+    });
+  }
+
+  if (preference === 'markdown') {
+    const markdownUrl = new URL(markdownSiblingPath(url.pathname), url);
+    const markdownResponse = await context.env.ASSETS.fetch(
+      markdownUrl.toString(),
+    );
+    if (markdownResponse.ok) {
+      const headers = new Headers(markdownResponse.headers);
+      headers.set('Vary', 'Accept');
+      return new Response(markdownResponse.body, {
+        status: markdownResponse.status,
+        headers,
+      });
+    }
+    // No Markdown sibling for this path (e.g. a non-docs route) — fall
+    // through and serve HTML instead of a hard 406.
+  }
+
+  const response = await context.next();
+  const headers = new Headers(response.headers);
+  headers.append('Vary', 'Accept');
+  return new Response(response.body, { status: response.status, headers });
+};

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -44,7 +44,7 @@ function parseAccept(header: string): AcceptEntry[] {
       if (!type) return null;
       let q = 1;
       for (const param of params) {
-        const [key, value] = param.trim().split('=');
+        const [key, value] = param.split('=').map((s) => s.trim());
         if (key === 'q' && value) q = Number.parseFloat(value) || 0;
       }
       const specificity = type === '*/*' ? 0 : type.endsWith('/*') ? 1 : 2;
@@ -54,8 +54,13 @@ function parseAccept(header: string): AcceptEntry[] {
 }
 
 // Highest (q * 10 + specificity) among entries matching `target`, or -1 if
-// nothing in the header would accept it.
+// nothing in the header would accept it. An exact-type entry with q=0 is a
+// hard exclusion (RFC 9110 §12.5.1) that a less-specific wildcard can't
+// override, so it's checked before falling back to wildcard matches.
 function scoreFor(entries: AcceptEntry[], target: string): number {
+  const exact = entries.find((e) => e.type === target);
+  if (exact && exact.q === 0) return -1;
+
   const group = `${target.split('/')[0]}/*`;
   let best = -1;
   for (const entry of entries) {
@@ -65,6 +70,19 @@ function scoreFor(entries: AcceptEntry[], target: string): number {
       best = Math.max(best, entry.q * 10 + entry.specificity);
   }
   return best;
+}
+
+// Adds Accept to a response's Vary header without dropping other Vary
+// dimensions the underlying asset/edge layer may have already set (e.g.
+// Accept-Encoding), and without duplicating Accept if it's already there.
+function addVaryAccept(headers: Headers): void {
+  const existing = headers.get('Vary');
+  const tokens = existing
+    ? existing.split(',').map((t) => t.trim().toLowerCase())
+    : [];
+  if (!tokens.includes('accept')) {
+    headers.set('Vary', existing ? `${existing}, Accept` : 'Accept');
+  }
 }
 
 type Preference = 'markdown' | 'html' | 'either' | 'none';
@@ -109,16 +127,21 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
   if (preference === 'markdown') {
     const markdownUrl = new URL(markdownSiblingPath(url.pathname), url);
+    // Preserve the original method (GET or HEAD) rather than always issuing
+    // a GET, so a HEAD probe doesn't pull down a full body it didn't ask for.
     const markdownResponse = await context.env.ASSETS.fetch(
-      markdownUrl.toString(),
+      new Request(markdownUrl, { method: request.method }),
     );
     if (markdownResponse.ok) {
       const headers = new Headers(markdownResponse.headers);
-      headers.set('Vary', 'Accept');
-      return new Response(markdownResponse.body, {
-        status: markdownResponse.status,
-        headers,
-      });
+      addVaryAccept(headers);
+      return new Response(
+        request.method === 'HEAD' ? null : markdownResponse.body,
+        {
+          status: markdownResponse.status,
+          headers,
+        },
+      );
     }
     // No Markdown sibling for this path (e.g. a non-docs route) — fall
     // through and serve HTML instead of a hard 406.
@@ -126,6 +149,6 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 
   const response = await context.next();
   const headers = new Headers(response.headers);
-  headers.append('Vary', 'Accept');
+  addVaryAccept(headers);
   return new Response(response.body, { status: response.status, headers });
 };

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "unified": "^11.0.5"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260910.1",
         "@lavamoat/allow-scripts": "^5.1.0",
         "@types/hast": "^3.0.5",
         "@types/react": "^19.2.18",
@@ -1066,6 +1067,13 @@
         "@clack/core": "1.1.0",
         "sisteransi": "^1.0.5"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260910.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260910.1.tgz",
+      "integrity": "sha512-heMipAW1SEPWaXCcleaxGMOEpvq/F4UKdc02Gb3xiLx1La5mE6VPFGBmOTGMt7kn+qX4L8D2WsYCfmrC4kKxLw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
       "version": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "unified": "^11.0.5"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260910.1",
     "@lavamoat/allow-scripts": "^5.1.0",
     "@types/hast": "^3.0.5",
     "@types/react": "^19.2.18",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
     "paths": {
       "~/*": ["src/*"]
     }
-  }
+  },
+  "exclude": ["functions"]
 }


### PR DESCRIPTION
## Summary
- Adds `functions/_middleware.ts`, a Cloudflare Pages Function that serves a page's Markdown sibling when the request's `Accept` header prefers `text/markdown` over `text/html` — on the same canonical URL a person would visit (e.g. `GET /ci/view-logs/` with `Accept: text/markdown` returns Markdown), with `Vary: Accept` on every negotiated response.
- The `<path>.md` URLs from #654 are unaffected; this adds negotiation on the canonical URL on top, which is what the Vercel and Cloudflare agent-friendliness scans check for.
- Falls back to HTML when a route has no Markdown sibling (e.g. non-docs pages), and only returns `406` when a client explicitly rejects every representation (`Accept: */*;q=0`).

## Why not Cloudflare's "Markdown for Agents" toggle
That's a dashboard setting under AI Crawl Control, but it's zone-level and requires the domain to be on Cloudflare DNS with a Pro/Business plan. Checked both Cloudflare accounts we have access to — neither has `shorebird.dev` as an actual zone, just the Pages custom domain via an external CNAME — so that toggle isn't reachable without a larger DNS migration. This reimplements the negotiation logic ourselves instead, following [acceptmarkdown.com's Cloudflare Workers recipe](https://acceptmarkdown.com/recipes/cloudflare-workers), adapted to a Pages Function rather than the from-scratch Workers-with-Assets setup the recipe describes, since we're already deploying via `wrangler pages deploy`.

## Notes
- `functions/` is excluded from the root `tsconfig.json` (so `astro check` skips it) since `@cloudflare/workers-types`' `Request`/`Response`/`Headers` overrides collide with the DOM lib types the rest of the project uses. It gets its own scoped `functions/tsconfig.json` instead, for editor support.

## Test plan
- [x] `npx tsc --noEmit -p functions/tsconfig.json` passes
- [x] `npm run build` (includes `astro check`) passes
- [x] Verified locally with `wrangler pages dev dist`:
  - [x] Browser-style `Accept` → HTML + `Vary: Accept`
  - [x] `Accept: text/markdown` → Markdown on the canonical URL, `content-type: text/markdown; charset=utf-8`
  - [x] No `Accept` header → HTML (safe default)
  - [x] Root `/` with `Accept: text/markdown` → `/index.md` content
  - [x] Competing q-values both directions (`text/markdown;q=0.9` beats `text/html;q=0.5` and vice versa)
  - [x] `Accept: */*;q=0` → `406`
  - [x] A route with no Markdown sibling (`/roadmap/`) → graceful HTML fallback, no error
  - [x] Explicit `.md` URLs and static assets unaffected
- [ ] After merge: verify on `docs.shorebird.dev` directly