### PR TITLE
fix: conform auth.md and ai-catalog.json to isitagentready.com specs

### DIFF
--- a/public/.well-known/ai-catalog.json
+++ b/public/.well-known/ai-catalog.json
@@ -1,13 +1,14 @@
 {
   "specVersion": "0.1.0",
   "host": {
+    "identifier": "did:web:shorebird.dev",
     "domain": "shorebird.dev",
     "displayName": "Shorebird",
     "description": "Code push and over-the-air update platform for Flutter applications across all supported platforms."
   },
   "entries": [
     {
-      "id": "urn:air:shorebird.dev:openapi:codepush-v1",
+      "identifier": "urn:air:shorebird.dev:openapi:codepush-v1",
       "displayName": "Shorebird Code Push API (OpenAPI 3.1)",
       "type": "application/json",
       "url": "https://api.shorebird.dev/openapi.json",
@@ -19,7 +20,7 @@
       ]
     },
     {
-      "id": "urn:air:shorebird.dev:docs:llms-txt",
+      "identifier": "urn:air:shorebird.dev:docs:llms-txt",
       "displayName": "Shorebird LLMs Documentation Index",
       "type": "text/plain",
       "url": "https://docs.shorebird.dev/llms.txt",
@@ -30,7 +31,7 @@
       ]
     },
     {
-      "id": "urn:air:shorebird.dev:docs:llms-full",
+      "identifier": "urn:air:shorebird.dev:docs:llms-full",
       "displayName": "Shorebird Complete Documentation (Full)",
       "type": "text/plain",
       "url": "https://docs.shorebird.dev/llms-full.txt",
@@ -41,7 +42,7 @@
       ]
     },
     {
-      "id": "urn:air:shorebird.dev:status:endpoint-reachability",
+      "identifier": "urn:air:shorebird.dev:status:endpoint-reachability",
       "displayName": "Shorebird Service Endpoint Reachability",
       "type": "text/html",
       "url": "https://docs.shorebird.dev/system/endpoint-reachability/",

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,6 +1,6 @@
 <!-- vale off -->
 
-# Authentication guide for agents and automated tooling
+# Shorebird auth.md — Authentication guide for agents and automated tooling
 
 This document describes how AI agents, scripts, and CI/CD pipelines authenticate
 with Shorebird services.


### PR DESCRIPTION
## Summary
Fixes the items from the latest isitagentready.com scan that are actually addressable from this repo. Fetched the exact `SKILL.md` for each item first rather than guessing.

- **`auth.md`**: heading must literally contain "auth.md". Was `# Authentication guide for agents and automated tooling`; changed to `# Shorebird auth.md — Authentication guide for agents and automated tooling`.
- **`ai-catalog.json` (ARD manifest)**: entries used `id` but the spec requires `identifier` — this is exactly why the scan said "entry 0 is missing identifier" even though every entry had a `urn:air:...` ID under the wrong key. Renamed on all 4 entries, and added the required `host.identifier` (used `did:web:shorebird.dev`, the format the skill doc's own example shows).

## Update after rebase
This branch originally also added an `agent_auth` block to `oauth-authorization-server`. **#659 (merged) deleted that file** — Eric found that it, along with `oauth-protected-resource` and `openid-configuration`, described an authorization server that doesn't actually exist: every endpoint they named 404s on `auth.shorebird.dev`, the scopes don't match the real API, and there's no OIDC or client-secret auth. My review of #657 checked the negotiation *mechanism* but never verified the auth metadata's *content* was accurate against the live server — that's on me. Rebased onto main, dropped the `agent_auth` addition (nothing to add it to anymore), kept the two fixes above which are unaffected.

## Not implemented — needs a decision or access this repo doesn't have
- **MCP Server Card** (`/.well-known/mcp/server-card.json`): Shorebird doesn't have an actual MCP server today (checked — no reference in docs content beyond the unrelated in-browser WebMCP script already in `Head.astro`). Publishing a card claiming one exists would be inaccurate. Needs a product decision on whether to build one.
- **DNS-AID** (SVCB/HTTPS records + DNSSEC under `_agents.docs.shorebird.dev`): requires DNS zone control. `docs.shorebird.dev`'s DNS isn't in either Cloudflare account available to this session (same gap from the earlier Cloudflare Pages migration).

## Out of scope for this repo entirely
The other 7 items from the numbered "Is Agentic" list (JSON error responses, rate-limit headers, typed error model, reachable API surface, onboarding friction, function-calling compatibility, versioning/deprecation policy) are all properties of `api.shorebird.dev` and `console.shorebird.dev` — separate services with their own codebases this session doesn't have access to.

## Test plan
- [x] Both edited JSON files validated (`python3 -m json.tool`)
- [x] `npm run build` passes
- [x] Verified via `wrangler pages dev` after rebasing: `oauth-authorization-server`/`oauth-protected-resource`/`openid-configuration` correctly 404 (confirming #659's deletion held), `auth.md` heading and `ai-catalog.json` fixes both intact
- [ ] After merge: re-run https://isitagentready.com/docs.shorebird.dev and https://is-agentic.com/scan/docs.shorebird.dev to confirm score movement