### PR TITLE
fix: add explicit agent-registration section to auth.md

### DIFF
--- a/public/auth.md
+++ b/public/auth.md
@@ -38,6 +38,25 @@ Interactive CLI sessions use short-lived JWTs (15 minutes) exchanged through
 - Agents should not hardcode or attempt to scrape short-lived OAuth tokens;
   prefer long-lived `sb_api_*` API keys.
 
+## Agent registration
+
+There is no separate registration API for agents. An agent (or the person
+operating it) registers for API access the same way a human developer does:
+
+1. Sign in or create a Shorebird account at
+   [console.shorebird.dev](https://console.shorebird.dev).
+2. Open **Account → API Keys**.
+3. Create an API key — this is the credential issuance step; the key
+   returned is the only artifact an agent needs to authenticate afterward.
+4. Store the key value; it is shown exactly once and cannot be retrieved
+   again.
+
+Registration endpoint: `https://console.shorebird.dev/account/api-keys`.
+Supported credential type: long-lived `sb_api_*` API keys (see
+[API keys](#1-api-keys-recommended-for-agents-and-automation) above for
+format and usage). There is no anonymous or unauthenticated registration
+path — a key must be created by an authenticated account.
+
 ## Protected resources
 
 - **API base URL**: `https://api.shorebird.dev/api/v1`

--- a/public/auth.md
+++ b/public/auth.md
@@ -41,20 +41,16 @@ Interactive CLI sessions use short-lived JWTs (15 minutes) exchanged through
 ## Agent registration
 
 There is no separate registration API for agents. An agent (or the person
-operating it) registers for API access the same way a human developer does:
+operating it) registers for API access the same way a human developer does: by
+creating an `sb_api_*` API key, as described under
+[API keys](#1-api-keys-recommended-for-agents-and-automation) above. That key is
+the credential issuance step; once issued, it's the only artifact an agent needs
+to authenticate.
 
-1. Sign in or create a Shorebird account at
-   [console.shorebird.dev](https://console.shorebird.dev).
-2. Open **Account → API Keys**.
-3. Create an API key — this is the credential issuance step; the key returned is
-   the only artifact an agent needs to authenticate afterward.
-4. Store the key value; it is shown exactly once and cannot be retrieved again.
-
-Registration endpoint: `https://console.shorebird.dev/account/api-keys`.
-Supported credential type: long-lived `sb_api_*` API keys (see
-[API keys](#1-api-keys-recommended-for-agents-and-automation) above for format
-and usage). There is no anonymous or unauthenticated registration path — a key
-must be created by an authenticated account.
+Registration page: `https://console.shorebird.dev/account/api-keys` — this is an
+authenticated web console, not a callable API. A human (or an agent driving a
+browser) must sign in there to issue a key; there is no anonymous,
+unauthenticated, or programmatic registration path.
 
 ## Protected resources
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -19,8 +19,7 @@ For automated agents, background workers, and CI/CD systems, use an `sb_api_*`
 API key.
 
 - **How to obtain**: Generate an API key in the
-  [Shorebird console](https://console.shorebird.dev/account/api-keys) (Account >
-  API Keys).
+  [Shorebird console](https://console.shorebird.dev) (Account > API Keys).
 - **Format**: `sb_api_<unique_token_characters>`
 - **Lifespan**: No expiry by default; an expiry in days can be set when the key
   is created.
@@ -47,9 +46,9 @@ creating an `sb_api_*` API key, as described under
 the credential issuance step; once issued, it's the only artifact an agent needs
 to authenticate.
 
-Registration page: `https://console.shorebird.dev/account/api-keys` — this is an
-authenticated web console, not a callable API. A human (or an agent driving a
-browser) must sign in there to issue a key; there is no anonymous,
+Registration page: `https://console.shorebird.dev` (Account > API Keys) — this
+is an authenticated web console, not a callable API. A human (or an agent
+driving a browser) must sign in there to issue a key; there is no anonymous,
 unauthenticated, or programmatic registration path.
 
 ## Protected resources

--- a/public/auth.md
+++ b/public/auth.md
@@ -46,16 +46,15 @@ operating it) registers for API access the same way a human developer does:
 1. Sign in or create a Shorebird account at
    [console.shorebird.dev](https://console.shorebird.dev).
 2. Open **Account → API Keys**.
-3. Create an API key — this is the credential issuance step; the key
-   returned is the only artifact an agent needs to authenticate afterward.
-4. Store the key value; it is shown exactly once and cannot be retrieved
-   again.
+3. Create an API key — this is the credential issuance step; the key returned is
+   the only artifact an agent needs to authenticate afterward.
+4. Store the key value; it is shown exactly once and cannot be retrieved again.
 
 Registration endpoint: `https://console.shorebird.dev/account/api-keys`.
 Supported credential type: long-lived `sb_api_*` API keys (see
-[API keys](#1-api-keys-recommended-for-agents-and-automation) above for
-format and usage). There is no anonymous or unauthenticated registration
-path — a key must be created by an authenticated account.
+[API keys](#1-api-keys-recommended-for-agents-and-automation) above for format
+and usage). There is no anonymous or unauthenticated registration path — a key
+must be created by an authenticated account.
 
 ## Protected resources
 


### PR DESCRIPTION
## Summary
isitagentready.com's live scan (re-run after #658/#659) reports **"auth.md exists but does not describe agent registration"** — its evidence shows a "Detect Auth.md registration markers" parse step finding none. Checked: the word "regist" doesn't appear anywhere in `auth.md` after #659 removed the fake OAuth endpoints (which had carried the only `registration_endpoint` reference).

Added a real "Agent registration" section — nothing fabricated, it's the same flow already documented under "API keys" above (self-serve key creation at `console.shorebird.dev/account/api-keys`), just made explicit under a heading and terminology a registration-marker detector can find: there's no separate agent registration API, an agent registers the same way a human does, and gets a long-lived `sb_api_*` key as the credential.

## Not addressed here — flagging instead of fabricating
Same live scan also fails **A2A Agent Card** — `/.well-known/agent-card.json` returns 404 (we have `/.well-known/agent.json` at the old path, from before the A2A spec renamed it). I'm not just moving/renaming the file: our current `agent.json` content doesn't match the real A2A `AgentCard` schema (fields like `supportedInterfaces` with a `protocolBinding`/`url` implying a live JSON-RPC or gRPC endpoint that actually speaks the A2A protocol — which Shorebird doesn't have; `api.shorebird.dev` is a plain REST API, not an A2A agent server). Publishing a spec-shaped card claiming A2A protocol support we don't have would repeat the exact mistake #659 just fixed for OAuth. Wanted a second opinion before touching this one — see the parent conversation.

## Test plan
- [x] `cspell` clean
- [x] `npm run build` passes
- [ ] Can't verify locally whether this satisfies the specific isitagentready.com check — it's a live scan against the deployed site. Will re-scan after merge+deploy.