### PR TITLE
docs: document --flutter-version=fvm and =system

### DIFF
--- a/src/content/docs/getting-started/flutter-version.mdx
+++ b/src/content/docs/getting-started/flutter-version.mdx
@@ -106,6 +106,32 @@ always be built with the version of Flutter used by the release.
 
 :::
 
+### Match the Flutter version you already use
+
+If you manage Flutter with [fvm](https://fvm.app), or you just want Shorebird to
+follow the `flutter` on your `PATH`, `--flutter-version` accepts two aliases so
+you don't have to repeat the version number:
+
+```sh
+# Use the version fvm resolves for this project (from its .fvmrc).
+shorebird release android --flutter-version=fvm
+
+# Use the version reported by the `flutter` on your PATH.
+shorebird release android --flutter-version=system
+```
+
+Shorebird asks that Flutter which version it is, then builds with Shorebird's
+fork of Flutter at the same version. It does not build with your fvm or system
+Flutter install, so the usual rules still apply: the version has to be one
+Shorebird supports, and patches are built with the version used by the release.
+
+:::note
+
+`--flutter-version=fvm` requires `fvm` on your `PATH`, and runs
+`fvm flutter --version` from your project directory to resolve the version.
+
+:::
+
 ### Flutter version notes
 
 To help you avoid hidden pitfalls, Shorebird maintains version notes on Flutter


### PR DESCRIPTION
## Status

**HOLD** — this documents a feature that has not shipped yet. It should merge only after shorebirdtech/shorebird#3932 lands and is in a released CLI.

## Description

Adds a "Match the Flutter version you already use" section to `getting-started/flutter-version.mdx`, covering the two `--flutter-version` aliases added in shorebirdtech/shorebird#3932:

- `--flutter-version=fvm` — uses the version fvm resolves for the project (from its `.fvmrc`).
- `--flutter-version=system` — uses the version reported by the `flutter` on your `PATH`.

The section makes the key point explicit, since it's the thing users are most likely to get wrong: Shorebird asks that Flutter which version it is, then builds with **Shorebird's fork at the same version**. It does not build with your fvm or system Flutter install, so the version still has to be one Shorebird supports, and patches are still built with the version used by the release.

Also notes that `--flutter-version=fvm` requires `fvm` on `PATH` and runs `fvm flutter --version` from the project directory.

Context: shorebirdtech/shorebird#1385 asked for fvm support "and/or at least docs on how they're supposed to work together" — this is the docs half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQV4ay9pqj2NUBhw72dLW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQV4ay9pqj2NUBhw72dLW8)_