### PR TITLE
docs: list builder prerequisites in the generic CI guide

### DIFF
--- a/src/content/docs/code-push/ci/generic.mdx
+++ b/src/content/docs/code-push/ci/generic.mdx
@@ -21,13 +21,9 @@ Flutter CI builds. Changes required:
 
 ## Prerequisites
 
-Shorebird downloads and manages its own copy of Flutter in `~/.shorebird`, so
-you do not need to install Flutter on the builder yourself. Shorebird does
-**not** install native platform toolchains — `shorebird release` and
-`shorebird patch` shell out to `flutter build`, which needs exactly the same
-toolchain it would need outside of Shorebird.
-
-A builder that has never run a Flutter build before will therefore need:
+Shorebird installs its own copy of Flutter in `~/.shorebird`. It does not
+install native platform toolchains. `shorebird release` and `shorebird patch`
+run `flutter build`, which needs the same toolchain it needs outside Shorebird:
 
 | Target      | Required on the builder                                                               |
 | ----------- | ------------------------------------------------------------------------------------- |
@@ -36,15 +32,12 @@ A builder that has never run a Flutter build before will therefore need:
 | Windows     | Visual Studio with the "Desktop development with C++" workload                        |
 | Linux       | `clang`, `cmake`, `ninja-build`, `pkg-config`, and `libgtk-3-dev`                     |
 
-To check what a builder actually has, run:
+`shorebird doctor --verbose` lists the Android Studio, Android SDK, ADB,
+`JAVA_HOME`, Java version, and Gradle it detects on the builder.
 
 ```bash
 shorebird doctor --verbose
 ```
-
-The verbose output lists the detected Android Studio, Android SDK, ADB,
-`JAVA_HOME`, Java version, and Gradle, which makes it easy to see which piece is
-missing before you debug a failing build.
 
 ## Supported CI providers
 

--- a/src/content/docs/code-push/ci/generic.mdx
+++ b/src/content/docs/code-push/ci/generic.mdx
@@ -29,20 +29,12 @@ toolchain it would need outside of Shorebird.
 
 A builder that has never run a Flutter build before will therefore need:
 
-| Target      | Required on the builder                                                                                      |
-| ----------- | ------------------------------------------------------------------------------------------------------------ |
-| Android     | A JDK (17 is a good default) and the Android SDK, with `ANDROID_HOME` (or `ANDROID_SDK_ROOT`) pointing at it |
-| iOS / macOS | Xcode, the Xcode command line tools, and CocoaPods                                                           |
-| Windows     | Visual Studio with the "Desktop development with C++" workload                                               |
-| Linux       | `clang`, `cmake`, `ninja-build`, `pkg-config`, and `libgtk-3-dev`                                            |
-
-:::caution
-
-Installing Shorebird does not install an Android SDK. If your builder is missing
-one, `shorebird release android` fails with `No Android SDK found` — the error
-comes from the underlying `flutter build`, not from Shorebird.
-
-:::
+| Target      | Required on the builder                                                               |
+| ----------- | ------------------------------------------------------------------------------------- |
+| Android     | A JDK and the Android SDK, with `ANDROID_HOME` (or `ANDROID_SDK_ROOT`) pointing at it |
+| iOS / macOS | Xcode, the Xcode command line tools, and CocoaPods                                    |
+| Windows     | Visual Studio with the "Desktop development with C++" workload                        |
+| Linux       | `clang`, `cmake`, `ninja-build`, `pkg-config`, and `libgtk-3-dev`                     |
 
 To check what a builder actually has, run:
 

--- a/src/content/docs/code-push/ci/generic.mdx
+++ b/src/content/docs/code-push/ci/generic.mdx
@@ -19,6 +19,43 @@ Flutter CI builds. Changes required:
 3. Replacing `flutter build --release` with `shorebird release` or
    `shorebird patch`.
 
+## Prerequisites
+
+Shorebird downloads and manages its own copy of Flutter in `~/.shorebird`, so
+you do not need to install Flutter on the builder yourself. Shorebird does
+**not** install native platform toolchains — `shorebird release` and
+`shorebird patch` shell out to `flutter build`, which needs exactly the same
+toolchain it would need outside of Shorebird.
+
+A builder that has never run a Flutter build before will therefore need:
+
+| Target      | Required on the builder                                                                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------------ |
+| Android     | A JDK (17 is a good default) and the Android SDK, with `ANDROID_HOME` (or `ANDROID_SDK_ROOT`) pointing at it |
+| iOS / macOS | Xcode, the Xcode command line tools, and CocoaPods                                                           |
+| Windows     | Visual Studio with the "Desktop development with C++" workload                                               |
+| Linux       | `clang`, `cmake`, `ninja-build`, `pkg-config`, and `libgtk-3-dev`                                            |
+
+:::caution
+
+Installing Shorebird does not install an Android SDK. If your builder is missing
+one, `shorebird release android` fails with `No Android SDK found` — the error
+comes from the underlying `flutter build`, not from Shorebird.
+
+:::
+
+To check what a builder actually has, run:
+
+```bash
+shorebird doctor --verbose
+```
+
+The verbose output lists the detected Android Studio, Android SDK, ADB,
+`JAVA_HOME`, Java version, and Gradle, which makes it easy to see which piece is
+missing before you debug a failing build.
+
+## Supported CI providers
+
 Detailed instructions are available for integrating into these providers:
 
 <LinkCard

--- a/src/content/docs/code-push/ci/generic.mdx
+++ b/src/content/docs/code-push/ci/generic.mdx
@@ -23,14 +23,11 @@ Flutter CI builds. Changes required:
 
 Shorebird installs its own copy of Flutter in `~/.shorebird`. It does not
 install native platform toolchains. `shorebird release` and `shorebird patch`
-run `flutter build`, which needs the same toolchain it needs outside Shorebird:
-
-| Target      | Required on the builder                                                               |
-| ----------- | ------------------------------------------------------------------------------------- |
-| Android     | A JDK and the Android SDK, with `ANDROID_HOME` (or `ANDROID_SDK_ROOT`) pointing at it |
-| iOS / macOS | Xcode, the Xcode command line tools, and CocoaPods                                    |
-| Windows     | Visual Studio with the "Desktop development with C++" workload                        |
-| Linux       | `clang`, `cmake`, `ninja-build`, `pkg-config`, and `libgtk-3-dev`                     |
+run `flutter build`, so a builder needs the same toolchain Flutter requires for
+your target platforms: a JDK and the Android SDK for Android, Xcode and
+CocoaPods for Apple platforms. See Flutter's
+[install requirements](https://docs.flutter.dev/get-started/install) for the
+full list.
 
 `shorebird doctor --verbose` lists the Android Studio, Android SDK, ADB,
 `JAVA_HOME`, Java version, and Gradle it detects on the builder.


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes shorebirdtech/shorebird#2925.

The generic CI guide goes from installing Shorebird to replacing `flutter build`, without saying the builder needs a native toolchain. The reporter followed it, hit `No Android SDK found`, and pointed out that the docs say Shorebird brings its own Flutter.

Adds a Prerequisites section saying Shorebird installs Flutter in `~/.shorebird` and does not install native toolchains, and that `shorebird release` / `shorebird patch` run `flutter build` and need whatever Flutter needs. Names the Android and Apple cases inline, since those are what CI builders hit, and links to [Flutter's install requirements](https://docs.flutter.dev/get-started/install) for the rest. Also points at `shorebird doctor --verbose`, which lists what it detects on the builder.

Moves the existing provider LinkCards under a "Supported CI providers" heading so they are not orphaned under the intro.

+19 lines, no deletions.

### Verification

- `npx prettier --write` — clean
- `npx cspell --config .cspell.yaml` — 0 issues
- `npx astro build` — all internal links valid
- `docs.flutter.dev/get-started/install` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fnEF9Ch8k5VQnwmBGD1nn