### PR TITLE
docs: explain patch-debug.zip and how to send it

### DIFF
--- a/src/content/docs/code-push/troubleshooting.mdx
+++ b/src/content/docs/code-push/troubleshooting.mdx
@@ -352,28 +352,26 @@ iOS uses a very different patching process than Android does. The details of
 which are described in [System Architecture](/code-push/system-architecture/).
 This is also discussed in the [Patch Performance](/code-push/performance/) page.
 
-If you are asked for a `patch-debug.zip`, see
+See
 [Sending a patch-debug.zip to Shorebird](#sending-a-patch-debugzip-to-shorebird)
-below.
+if you are asked for one.
 
 ---
 
 ## Sending a patch-debug.zip to Shorebird
 
-When Shorebird
-[links](/code-push/system-architecture#how-shorebird-code-push-works) an iOS
-patch against its release, it writes a diagnostic bundle to
-`build/patch-debug.zip` in your project. If you report a patch that runs slowly,
-or one that shares a low percentage of Dart code with its release, this is the
-single most useful thing you can send us.
+`shorebird patch ios` writes `build/patch-debug.zip` when it
+[links](/code-push/system-architecture#how-shorebird-code-push-works) the patch
+against its release. Send it with any report of a slow patch or a low
+shared-code percentage.
 
 ### When it is produced
 
-`patch-debug.zip` is written by `shorebird patch ios` as part of the linking
-step. Android patches do not use the linker and do not produce one.
+Every `shorebird patch ios` run writes one. Android patches do not use the
+linker and do not produce one.
 
-Shorebird only mentions it in the patch summary when the link percentage falls
-below 90%:
+Shorebird names it in the patch summary only when the link percentage is below
+90%:
 
 ```
 🔍 Debug Info: build/patch-debug.zip
@@ -390,9 +388,8 @@ providers, archive it before the runner is torn down.
 ### What is inside
 
 The compiled Dart snapshots from both sides of the link, plus the link metadata
-Shorebird uses to compute the shared-code percentage. Together these let us
-reproduce the link offline and see exactly which code did not get shared between
-your release and your patch, without needing access to your project.
+Shorebird uses to compute the shared-code percentage. These let us reproduce the
+link and see which code was not shared, without access to your project.
 
 :::note
 
@@ -405,12 +402,11 @@ Shorebird credentials.
 
 ### How to send it
 
-We need three things: your app ID, the release version, and the file.
+Send your app ID, the release version, and the file.
 
-Attaching it to a
-[GitHub issue](https://github.com/shorebirdtech/shorebird/issues) is usually
-easiest. Many apps are not private, so uploading it publicly is fine. If yours
-is, send it privately instead: [Discord](https://discord.gg/shorebird),
+A [GitHub issue](https://github.com/shorebirdtech/shorebird/issues) is usually
+easiest, and a public upload is fine for most apps. For a private app, use
+[Discord](https://discord.gg/shorebird),
 [contact@shorebird.dev](mailto:contact@shorebird.dev), or your shared Slack
 channel if you are an enterprise customer.
 

--- a/src/content/docs/code-push/troubleshooting.mdx
+++ b/src/content/docs/code-push/troubleshooting.mdx
@@ -352,6 +352,83 @@ iOS uses a very different patching process than Android does. The details of
 which are described in [System Architecture](/code-push/system-architecture/).
 This is also discussed in the [Patch Performance](/code-push/performance/) page.
 
+If you are asked for a `patch-debug.zip`, see
+[Sending a patch-debug.zip to Shorebird](#sending-a-patch-debugzip-to-shorebird)
+below.
+
+---
+
+## Sending a patch-debug.zip to Shorebird
+
+When Shorebird links an iOS or macOS patch against its release, it writes a
+diagnostic bundle to `build/patch-debug.zip` in your project. If you report a
+patch that runs slowly, or a patch that reports a low percentage of shared Dart
+code, this is the single most useful thing you can send us.
+
+### When it is produced
+
+`patch-debug.zip` is written by `shorebird patch ios` and
+`shorebird patch macos` as part of the linking step. Android patches do not use
+the linker and do not produce one.
+
+The file is written on every such patch, but Shorebird only mentions it in the
+patch summary when the link percentage falls below 90%:
+
+```
+🔍 Debug Info: build/patch-debug.zip
+```
+
+So if you did not see that line, the file is still there — look for it anyway.
+
+### Where to find it
+
+| Where you built | Path                                                              |
+| --------------- | ----------------------------------------------------------------- |
+| Locally         | `build/patch-debug.zip`, relative to your project root            |
+| Codemagic       | Also copied to `$CM_EXPORT_DIR`, so it appears in build artifacts |
+| Other CI        | `build/patch-debug.zip` — upload it as a build artifact           |
+
+On CI, `build/` is usually discarded when the job ends, so add a step that
+archives `build/patch-debug.zip` before the runner is torn down.
+
+### What is inside
+
+The archive contains a `snapshots/` directory holding the compiled Dart
+snapshots from both sides of the link, plus the link metadata Shorebird uses to
+compute the shared-code percentage:
+
+| File                     | What it is                                         |
+| ------------------------ | -------------------------------------------------- |
+| `App`                    | The AOT snapshot from the release you are patching |
+| `out.aot`                | The patch's initial compiler output                |
+| `out.ct.aot`             | Intermediate linking stage                         |
+| `out.preDdOptimized.aot` | Intermediate linking stage                         |
+| `out.ddOnly.aot`         | Intermediate linking stage                         |
+| `out.optimized.aot`      | The final linked patch snapshot                    |
+
+Together these let us reproduce the link offline and see exactly which code did
+not get shared between your release and your patch, without needing access to
+your project.
+
+:::caution
+
+`patch-debug.zip` contains compiled Dart code from your app — the same code that
+ships inside your release binary. It contains no Shorebird credentials and no
+source files, but treat it with the same care you would treat your app binary,
+and send it over a private channel rather than posting it publicly.
+
+:::
+
+### How to send it
+
+Share it with us on [Discord](https://discord.gg/shorebird) or by email at
+[contact@shorebird.dev](mailto:contact@shorebird.dev), along with:
+
+- your release version and the platform you patched,
+- the link percentage Shorebird reported, if you saw one,
+- the output of `shorebird --version`, and
+- the Flutter version used for the release.
+
 ---
 
 ## Resolving persistent compile or build failures

--- a/src/content/docs/code-push/troubleshooting.mdx
+++ b/src/content/docs/code-push/troubleshooting.mdx
@@ -388,8 +388,9 @@ providers, archive it before the runner is torn down.
 ### What is inside
 
 The compiled Dart snapshots from both sides of the link, plus the link metadata
-Shorebird uses to compute the shared-code percentage. These let us reproduce the
-link and see which code was not shared, without access to your project.
+Shorebird uses to compute the shared-code percentage. That is enough to
+reproduce the link and identify which code was not shared, without access to
+your project.
 
 :::note
 

--- a/src/content/docs/code-push/troubleshooting.mdx
+++ b/src/content/docs/code-push/troubleshooting.mdx
@@ -360,74 +360,59 @@ below.
 
 ## Sending a patch-debug.zip to Shorebird
 
-When Shorebird links an iOS or macOS patch against its release, it writes a
-diagnostic bundle to `build/patch-debug.zip` in your project. If you report a
-patch that runs slowly, or a patch that reports a low percentage of shared Dart
-code, this is the single most useful thing you can send us.
+When Shorebird
+[links](/code-push/system-architecture#how-shorebird-code-push-works) an iOS
+patch against its release, it writes a diagnostic bundle to
+`build/patch-debug.zip` in your project. If you report a patch that runs slowly,
+or one that shares a low percentage of Dart code with its release, this is the
+single most useful thing you can send us.
 
 ### When it is produced
 
-`patch-debug.zip` is written by `shorebird patch ios` and
-`shorebird patch macos` as part of the linking step. Android patches do not use
-the linker and do not produce one.
+`patch-debug.zip` is written by `shorebird patch ios` as part of the linking
+step. Android patches do not use the linker and do not produce one.
 
-The file is written on every such patch, but Shorebird only mentions it in the
-patch summary when the link percentage falls below 90%:
+Shorebird only mentions it in the patch summary when the link percentage falls
+below 90%:
 
 ```
 🔍 Debug Info: build/patch-debug.zip
 ```
 
-So if you did not see that line, the file is still there — look for it anyway.
+Even if you did not see that line, the file is still there.
 
 ### Where to find it
 
-| Where you built | Path                                                              |
-| --------------- | ----------------------------------------------------------------- |
-| Locally         | `build/patch-debug.zip`, relative to your project root            |
-| Codemagic       | Also copied to `$CM_EXPORT_DIR`, so it appears in build artifacts |
-| Other CI        | `build/patch-debug.zip` — upload it as a build artifact           |
-
-On CI, `build/` is usually discarded when the job ends, so add a step that
-archives `build/patch-debug.zip` before the runner is torn down.
+`build/patch-debug.zip`, relative to your project root. Codemagic respects
+`$CM_EXPORT_DIR`, so it also shows up in your build artifacts there. On other CI
+providers, archive it before the runner is torn down.
 
 ### What is inside
 
-The archive contains a `snapshots/` directory holding the compiled Dart
-snapshots from both sides of the link, plus the link metadata Shorebird uses to
-compute the shared-code percentage:
+The compiled Dart snapshots from both sides of the link, plus the link metadata
+Shorebird uses to compute the shared-code percentage. Together these let us
+reproduce the link offline and see exactly which code did not get shared between
+your release and your patch, without needing access to your project.
 
-| File                     | What it is                                         |
-| ------------------------ | -------------------------------------------------- |
-| `App`                    | The AOT snapshot from the release you are patching |
-| `out.aot`                | The patch's initial compiler output                |
-| `out.ct.aot`             | Intermediate linking stage                         |
-| `out.preDdOptimized.aot` | Intermediate linking stage                         |
-| `out.ddOnly.aot`         | Intermediate linking stage                         |
-| `out.optimized.aot`      | The final linked patch snapshot                    |
+:::note
 
-Together these let us reproduce the link offline and see exactly which code did
-not get shared between your release and your patch, without needing access to
-your project.
-
-:::caution
-
-`patch-debug.zip` contains compiled Dart code from your app — the same code that
-ships inside your release binary. It contains no Shorebird credentials and no
-source files, but treat it with the same care you would treat your app binary,
-and send it over a private channel rather than posting it publicly.
+`patch-debug.zip` contains your app's compiled Dart code. It is only partially
+compiled and names may not be obfuscated, so treat it as more sensitive than the
+binary you ship publicly, though less sensitive than your source. It contains no
+Shorebird credentials.
 
 :::
 
 ### How to send it
 
-Share it with us on [Discord](https://discord.gg/shorebird) or by email at
-[contact@shorebird.dev](mailto:contact@shorebird.dev), along with:
+We need three things: your app ID, the release version, and the file.
 
-- your release version and the platform you patched,
-- the link percentage Shorebird reported, if you saw one,
-- the output of `shorebird --version`, and
-- the Flutter version used for the release.
+Attaching it to a
+[GitHub issue](https://github.com/shorebirdtech/shorebird/issues) is usually
+easiest. Many apps are not private, so uploading it publicly is fine. If yours
+is, send it privately instead: [Discord](https://discord.gg/shorebird),
+[contact@shorebird.dev](mailto:contact@shorebird.dev), or your shared Slack
+channel if you are an enterprise customer.
 
 ---
 


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #332.

`patch-debug.zip` is not in the docs, but `shorebird patch` prints its path in the patch summary and support asks users for it. Adds a troubleshooting section, where the issue suggested it belongs.

Claims and their sources in the CLI:

| Claim | Source |
| --- | --- |
| Written to `build/patch-debug.zip` | `Patcher.debugInfoFile` (`patcher.dart:259`) |
| iOS only | `apple.runLinker` is called from `ios_patcher.dart` and `ios_framework_patcher.dart`, not `macos_patcher.dart` |
| Also copied to `$CM_EXPORT_DIR` on Codemagic | `apple.dart:232-246` |
| Named in the summary only below 90% link | `patch_command.dart:735-737` and `Patcher.linkPercentageWarningThreshold` |

The part worth a second look: the file is written on every run but only named in the summary below 90%. That asymmetry is in the code and is what users need to know, but it will need updating if the summary logic changes.

### Verification

- `npx prettier --write` — clean
- `npx cspell --config .cspell.yaml` — 0 issues
- `npx astro build` — all internal links valid, including the new `#sending-a-patch-debugzip-to-shorebird` cross-reference and the System Architecture deep link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fnEF9Ch8k5VQnwmBGD1nn