### PR TITLE
docs: document Android keystore setup in the GitHub CI guide

### DIFF
--- a/src/content/docs/code-push/ci/github.mdx
+++ b/src/content/docs/code-push/ci/github.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 8
 ---
 
-{/* cspell:words shorebirdtech */}
+{/* cspell:words shorebirdtech appbundle */}
 
 import Authentication from './_authentication.mdx';
 import { LinkCard } from 'starlight-theme-nova/components';
@@ -86,6 +86,125 @@ secret: <THE GENERATED SHOREBIRD_TOKEN>
 
 Now the `SHOREBIRD_TOKEN` can be used in the GitHub workflow to perform
 authenticated functions such as creating patches 🎉
+
+## Android code signing
+
+Shorebird does not sign your app. `shorebird release android` and
+`shorebird patch android` run Gradle, and Gradle signs with whatever release
+signing configuration your project already has. A fresh GitHub runner has no
+keystore, so unless you put one there, Gradle falls back to the debug signing
+key and the resulting build is rejected by the Play Console or fails to install
+over an existing copy of your app with `INSTALL_PARSE_FAILED_NO_CERTIFICATES`.
+
+`shorebird patch android` needs this too. Patching rebuilds your app so it can
+be compared against the released version, so the runner needs the same signing
+configuration the release was built with.
+
+### Store the keystore as a secret
+
+A keystore is a binary file, so base64-encode it before putting it in a GitHub
+secret:
+
+```bash title="macOS"
+base64 -i upload-keystore.jks | pbcopy
+```
+
+```bash title="Linux"
+base64 -w 0 upload-keystore.jks
+```
+
+Add the result as a repository secret named `ANDROID_KEYSTORE_BASE64`, then add
+three more secrets for the credentials: `ANDROID_KEYSTORE_PASSWORD`,
+`ANDROID_KEY_PASSWORD`, and `ANDROID_KEY_ALIAS`.
+
+:::danger
+
+Never commit `upload-keystore.jks` or `android/key.properties` to your
+repository. Both belong in `.gitignore`. Losing the upload key means you can no
+longer update your app on the Play Store without contacting Google, so keep a
+backup somewhere safe.
+
+:::
+
+### Recreate the keystore on the runner
+
+Add a step that decodes the keystore and writes `android/key.properties` before
+any Shorebird step runs:
+
+```yaml
+- name: 🔐 Set up Android signing
+  env:
+    KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+    KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+    KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+    KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+  run: |
+    echo "$KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+    cat <<PROPS > android/key.properties
+    storePassword=$KEYSTORE_PASSWORD
+    keyPassword=$KEY_PASSWORD
+    keyAlias=$KEY_ALIAS
+    storeFile=upload-keystore.jks
+    PROPS
+```
+
+:::note
+
+`storeFile` is resolved relative to `android/app`, which is why the path above
+is just the file name.
+
+Pass the secrets through `env:` rather than interpolating them directly into the
+`run:` script. Interpolated values are expanded into the shell command itself,
+which makes them easier to leak into logs or into a crafted branch name.
+
+:::
+
+This assumes your `android/app/build.gradle` (or `build.gradle.kts`) already
+reads `key.properties` for its release signing config. If you have not set that
+up yet, see
+[Releasing Flutter apps: Android](/flutter-concepts/releasing-flutter-apps/android#step-3-configure-signing-in-gradle),
+which covers creating the keystore and wiring it into Gradle. If you can build a
+signed release locally with `flutter build appbundle`, your project is already
+set up correctly and only the runner needs these steps.
+
+### Putting it together
+
+```yaml
+steps:
+  - name: 📚 Git Checkout
+    uses: actions/checkout@v7
+
+  - name: 🐦 Setup Shorebird
+    uses: shorebirdtech/setup-shorebird@v1
+    with:
+      cache: true
+
+  - name: Set up Java
+    uses: actions/setup-java@v4
+    with:
+      distribution: 'temurin'
+      java-version: '17'
+
+  - name: 🔐 Set up Android signing
+    env:
+      KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+      KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+    run: |
+      echo "$KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+      cat <<PROPS > android/key.properties
+      storePassword=$KEYSTORE_PASSWORD
+      keyPassword=$KEY_PASSWORD
+      keyAlias=$KEY_ALIAS
+      storeFile=upload-keystore.jks
+      PROPS
+
+  - name: 🚀 Shorebird Release
+    uses: shorebirdtech/shorebird-release@v1
+    with:
+      platform: android
+```
 
 ## Create releases
 

--- a/src/content/docs/code-push/ci/github.mdx
+++ b/src/content/docs/code-push/ci/github.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 8
 ---
 
-{/* cspell:words shorebirdtech appbundle */}
+{/* cspell:words shorebirdtech */}
 
 import Authentication from './_authentication.mdx';
 import { LinkCard } from 'starlight-theme-nova/components';
@@ -90,41 +90,19 @@ authenticated functions such as creating patches 🎉
 ## Android code signing
 
 `shorebird release android` and `shorebird patch android` run `flutter build`,
-so signing works exactly as it does for any Flutter app. See
-[Releasing Flutter apps: Android](/flutter-concepts/releasing-flutter-apps/android#step-3-configure-signing-in-gradle)
-for creating a keystore and wiring it into Gradle.
+so signing works exactly as it does for any Flutter app. Follow
+[Flutter's Android signing instructions](https://docs.flutter.dev/deployment/android#sign-the-app),
+or the
+[Shorebird version of them](/flutter-concepts/releasing-flutter-apps/android#step-3-configure-signing-in-gradle).
 
-The CI-specific part is getting the keystore onto the runner. Store it as a
-base64-encoded repository secret, then decode it and write
-`android/key.properties` before the Shorebird step runs:
+The only difference on CI is that the keystore is not already on the machine.
+Store it as a base64-encoded repository secret, decode it to a path outside your
+checkout, and point `key.properties` at that path before the Shorebird step
+runs.
 
-```yaml
-- name: 🔐 Set up Android signing
-  env:
-    KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-    KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-    KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-    KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-  run: |
-    echo "$KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
-    cat <<PROPS > android/key.properties
-    storePassword=$KEYSTORE_PASSWORD
-    keyPassword=$KEY_PASSWORD
-    keyAlias=$KEY_ALIAS
-    storeFile=upload-keystore.jks
-    PROPS
-```
-
-Without this, Gradle falls back to the debug key. The Play Console rejects those
+Without it, Gradle falls back to the debug key. The Play Console rejects those
 builds, and they fail to install over an existing copy of your app with
 `INSTALL_PARSE_FAILED_NO_CERTIFICATES`.
-
-:::danger
-
-Never commit `upload-keystore.jks` or `android/key.properties`. Both belong in
-`.gitignore`.
-
-:::
 
 ## Create releases
 

--- a/src/content/docs/code-push/ci/github.mdx
+++ b/src/content/docs/code-push/ci/github.mdx
@@ -89,21 +89,18 @@ authenticated functions such as creating patches 🎉
 
 ## Android code signing
 
-Shorebird does not sign your app. `shorebird release android` and
-`shorebird patch android` run Gradle, and Gradle signs with whatever release
-signing configuration your project already has. A fresh GitHub runner has no
-keystore, so unless you put one there, Gradle falls back to the debug signing
-key and the resulting build is rejected by the Play Console or fails to install
-over an existing copy of your app with `INSTALL_PARSE_FAILED_NO_CERTIFICATES`.
+`shorebird release android` and `shorebird patch android` run Gradle, which
+signs with your project's release signing configuration. A GitHub runner has no
+keystore by default, so Gradle falls back to the debug key. The Play Console
+rejects those builds, and they fail to install over an existing copy of your app
+with `INSTALL_PARSE_FAILED_NO_CERTIFICATES`.
 
-`shorebird patch android` needs this too. Patching rebuilds your app so it can
-be compared against the released version, so the runner needs the same signing
-configuration the release was built with.
+`shorebird patch android` rebuilds your app to compare it against the release,
+so it needs the same signing configuration as the release.
 
 ### Store the keystore as a secret
 
-A keystore is a binary file, so base64-encode it before putting it in a GitHub
-secret:
+A keystore is a binary file. Base64-encode it first:
 
 ```bash title="macOS"
 base64 -i upload-keystore.jks | pbcopy
@@ -113,23 +110,21 @@ base64 -i upload-keystore.jks | pbcopy
 base64 -w 0 upload-keystore.jks
 ```
 
-Add the result as a repository secret named `ANDROID_KEYSTORE_BASE64`, then add
-three more secrets for the credentials: `ANDROID_KEYSTORE_PASSWORD`,
-`ANDROID_KEY_PASSWORD`, and `ANDROID_KEY_ALIAS`.
+Add the result as a repository secret named `ANDROID_KEYSTORE_BASE64`, plus
+`ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_PASSWORD`, and `ANDROID_KEY_ALIAS`.
 
 :::danger
 
-Never commit `upload-keystore.jks` or `android/key.properties` to your
-repository. Both belong in `.gitignore`. Losing the upload key means you can no
-longer update your app on the Play Store without contacting Google, so keep a
-backup somewhere safe.
+Never commit `upload-keystore.jks` or `android/key.properties`. Both belong in
+`.gitignore`. Losing the upload key means you cannot update your app on the Play
+Store without contacting Google, so keep a backup.
 
 :::
 
 ### Recreate the keystore on the runner
 
-Add a step that decodes the keystore and writes `android/key.properties` before
-any Shorebird step runs:
+Decode the keystore and write `android/key.properties` before any Shorebird step
+runs:
 
 ```yaml
 - name: 🔐 Set up Android signing
@@ -150,22 +145,20 @@ any Shorebird step runs:
 
 :::note
 
-`storeFile` is resolved relative to `android/app`, which is why the path above
-is just the file name.
+`storeFile` resolves relative to `android/app`, so the path above is just the
+file name.
 
-Pass the secrets through `env:` rather than interpolating them directly into the
-`run:` script. Interpolated values are expanded into the shell command itself,
-which makes them easier to leak into logs or into a crafted branch name.
+Pass the secrets through `env:` rather than interpolating them into the `run:`
+script. Interpolated values are expanded into the shell command itself, where
+they are easier to leak into logs.
 
 :::
 
-This assumes your `android/app/build.gradle` (or `build.gradle.kts`) already
-reads `key.properties` for its release signing config. If you have not set that
-up yet, see
-[Releasing Flutter apps: Android](/flutter-concepts/releasing-flutter-apps/android#step-3-configure-signing-in-gradle),
-which covers creating the keystore and wiring it into Gradle. If you can build a
-signed release locally with `flutter build appbundle`, your project is already
-set up correctly and only the runner needs these steps.
+This assumes `android/app/build.gradle` (or `build.gradle.kts`) already reads
+`key.properties` for its release signing config. See
+[Releasing Flutter apps: Android](/flutter-concepts/releasing-flutter-apps/android#step-3-configure-signing-in-gradle)
+to set that up. If `flutter build appbundle` produces a signed release locally,
+only the runner needs these steps.
 
 ### Putting it together
 

--- a/src/content/docs/code-push/ci/github.mdx
+++ b/src/content/docs/code-push/ci/github.mdx
@@ -89,42 +89,14 @@ authenticated functions such as creating patches 🎉
 
 ## Android code signing
 
-`shorebird release android` and `shorebird patch android` run Gradle, which
-signs with your project's release signing configuration. A GitHub runner has no
-keystore by default, so Gradle falls back to the debug key. The Play Console
-rejects those builds, and they fail to install over an existing copy of your app
-with `INSTALL_PARSE_FAILED_NO_CERTIFICATES`.
+`shorebird release android` and `shorebird patch android` run `flutter build`,
+so signing works exactly as it does for any Flutter app. See
+[Releasing Flutter apps: Android](/flutter-concepts/releasing-flutter-apps/android#step-3-configure-signing-in-gradle)
+for creating a keystore and wiring it into Gradle.
 
-`shorebird patch android` rebuilds your app to compare it against the release,
-so it needs the same signing configuration as the release.
-
-### Store the keystore as a secret
-
-A keystore is a binary file. Base64-encode it first:
-
-```bash title="macOS"
-base64 -i upload-keystore.jks | pbcopy
-```
-
-```bash title="Linux"
-base64 -w 0 upload-keystore.jks
-```
-
-Add the result as a repository secret named `ANDROID_KEYSTORE_BASE64`, plus
-`ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_PASSWORD`, and `ANDROID_KEY_ALIAS`.
-
-:::danger
-
-Never commit `upload-keystore.jks` or `android/key.properties`. Both belong in
-`.gitignore`. Losing the upload key means you cannot update your app on the Play
-Store without contacting Google, so keep a backup.
-
-:::
-
-### Recreate the keystore on the runner
-
-Decode the keystore and write `android/key.properties` before any Shorebird step
-runs:
+The CI-specific part is getting the keystore onto the runner. Store it as a
+base64-encoded repository secret, then decode it and write
+`android/key.properties` before the Shorebird step runs:
 
 ```yaml
 - name: 🔐 Set up Android signing
@@ -143,61 +115,16 @@ runs:
     PROPS
 ```
 
-:::note
+Without this, Gradle falls back to the debug key. The Play Console rejects those
+builds, and they fail to install over an existing copy of your app with
+`INSTALL_PARSE_FAILED_NO_CERTIFICATES`.
 
-`storeFile` resolves relative to `android/app`, so the path above is just the
-file name.
+:::danger
 
-Pass the secrets through `env:` rather than interpolating them into the `run:`
-script. Interpolated values are expanded into the shell command itself, where
-they are easier to leak into logs.
+Never commit `upload-keystore.jks` or `android/key.properties`. Both belong in
+`.gitignore`.
 
 :::
-
-This assumes `android/app/build.gradle` (or `build.gradle.kts`) already reads
-`key.properties` for its release signing config. See
-[Releasing Flutter apps: Android](/flutter-concepts/releasing-flutter-apps/android#step-3-configure-signing-in-gradle)
-to set that up. If `flutter build appbundle` produces a signed release locally,
-only the runner needs these steps.
-
-### Putting it together
-
-```yaml
-steps:
-  - name: 📚 Git Checkout
-    uses: actions/checkout@v7
-
-  - name: 🐦 Setup Shorebird
-    uses: shorebirdtech/setup-shorebird@v1
-    with:
-      cache: true
-
-  - name: Set up Java
-    uses: actions/setup-java@v4
-    with:
-      distribution: 'temurin'
-      java-version: '17'
-
-  - name: 🔐 Set up Android signing
-    env:
-      KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-      KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-      KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-      KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-    run: |
-      echo "$KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
-      cat <<PROPS > android/key.properties
-      storePassword=$KEYSTORE_PASSWORD
-      keyPassword=$KEY_PASSWORD
-      keyAlias=$KEY_ALIAS
-      storeFile=upload-keystore.jks
-      PROPS
-
-  - name: 🚀 Shorebird Release
-    uses: shorebirdtech/shorebird-release@v1
-    with:
-      platform: android
-```
 
 ## Create releases
 


### PR DESCRIPTION
## Status

**READY**

## Description

Fixes #338.

The GitHub Actions guide mentions signing once, in a YAML comment saying signing information must be set up on the runner, with no instructions for doing it.

Adds a short "Android code signing" section: `flutter build` does the signing, so it is standard Flutter — links to [Flutter's instructions](https://docs.flutter.dev/deployment/android#sign-the-app) and to ours — plus the one thing neither covers. On CI the keystore is not already on the machine, so store it as a base64 secret, decode it outside the checkout, and point `key.properties` at it. Then what happens if you skip it.

+17 lines, no YAML.

### What changed during review

Started at 90 lines with a full workflow, a secret-storage subsection, and two callouts. Now three paragraphs. Three things were wrong or unnecessary:

- The claim that `shorebird patch android` needs the same signing config. `AndroidArchiveDiffer.changedFiles` does report `META-INF/*` as changed, but warnings come from `containsPotentiallyBreakingAssetDiffs` (`assets`/`res`/`AssetManifest.json`) and `containsPotentiallyBreakingNativeDiffs` (`.dex`). `META-INF` matches neither.
- "Shorebird does not sign your app" as the framing. Gradle signs, during `flutter build`; Shorebird requires nothing.
- A hand-written recipe where links would do.

The earlier snippet also decoded the keystore into `android/app/`. `_zap`'s release workflow decodes to `$RUNNER_TEMP` instead, which is better, so the prose says "outside your checkout".

### On the standard-action question

There is no action for this half. Gradle signs during `flutter build`, so the keystore has to be in place first; the common actions (`r0adkll/sign-android-release` and similar) sign an artifact after it is built. `_zap` hand-rolls the decode step for the same reason and uses an action only for the Play upload.

### Verification

- `npx prettier --write` — clean
- `npx cspell --config .cspell.yaml` — 0 issues
- `vale 3.21.0 --config=.vale.ini src/content/docs` — 0 errors, matching the version CI installs
- `npx astro build` — all internal links valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fnEF9Ch8k5VQnwmBGD1nn