### PR TITLE
docs: clarify active vs superseded patches

### DIFF
--- a/src/content/docs/code-push/rollback.mdx
+++ b/src/content/docs/code-push/rollback.mdx
@@ -44,6 +44,45 @@ Roll back requires a minimum Flutter version of 3.27.4.
   title="Roll Back a Patch"
 />
 
+## Active and superseded patches
+
+Before rolling anything back, it helps to know how Shorebird decides which patch
+a device gets, because the answer surprises people.
+
+When a device checks in, Shorebird serves **the highest-numbered patch on that
+device's track that has not been rolled back**. There is no per-patch on/off
+switch that you have to manage. Publishing patch 3 does not require turning
+patch 2 off; patch 3 simply outranks it.
+
+That means:
+
+- Only one patch is ever served per track at a time. The Console shows it as the
+  active patch.
+- Every lower-numbered patch is already superseded. You do not need to
+  deactivate historical patches, and doing so changes nothing about what devices
+  receive today.
+- Rolling back the active patch is how you go backwards. Devices then fall to
+  the next-highest patch on the track that has not been rolled back, or to the
+  base release if there is none.
+
+So to return users to patch 1 when patch 3 is live, roll back patch 3 and
+patch 2. You do not roll back patch 1 and you do not re-publish it.
+
+:::note
+
+Rolling back a patch that is already superseded has no immediate effect, because
+devices are not being served it anyway. It only removes that patch from the set
+of patches devices could fall back to later.
+
+:::
+
+### Why the Console may still show old patches installing
+
+Patch install events are reported the next time an app launches, which can be
+hours or days after the install happened. A patch that is no longer being served
+can therefore keep showing new install events for a while. This is a reporting
+delay, not devices downloading an old patch.
+
 ## How to roll back a patch
 
 In the [Shorebird Console](https://console.shorebird.dev/), navigate to the

--- a/src/content/docs/code-push/rollback.mdx
+++ b/src/content/docs/code-push/rollback.mdx
@@ -46,42 +46,34 @@ Roll back requires a minimum Flutter version of 3.27.4.
 
 ## Active and superseded patches
 
-Before rolling anything back, it helps to know how Shorebird decides which patch
-a device gets, because the answer surprises people.
+When a device checks in, Shorebird serves the highest-numbered patch on that
+device's track that has not been rolled back. The Console shows that patch as
+active.
 
-When a device checks in, Shorebird serves **the highest-numbered patch on that
-device's track that has not been rolled back**. There is no per-patch on/off
-switch that you have to manage. Publishing patch 3 does not require turning
-patch 2 off; patch 3 simply outranks it.
+Patches have no individual on/off switch. Publishing patch 3 outranks patch 2
+without any action on patch 2:
 
-That means:
+- One patch is served per track at a time.
+- Lower-numbered patches are superseded. Deactivating them changes nothing about
+  what devices receive.
+- Rolling back the active patch moves devices to the next-highest patch on the
+  track that has not been rolled back, or to the base release.
 
-- Only one patch is ever served per track at a time. The Console shows it as the
-  active patch.
-- Every lower-numbered patch is already superseded. You do not need to
-  deactivate historical patches, and doing so changes nothing about what devices
-  receive today.
-- Rolling back the active patch is how you go backwards. Devices then fall to
-  the next-highest patch on the track that has not been rolled back, or to the
-  base release if there is none.
-
-So to return users to patch 1 when patch 3 is live, roll back patch 3 and
-patch 2. You do not roll back patch 1 and you do not re-publish it.
+To return users to patch 1 while patch 3 is live, roll back patch 3 and patch 2.
+Leave patch 1 alone.
 
 :::note
 
-Rolling back a patch that is already superseded has no immediate effect, because
-devices are not being served it anyway. It only removes that patch from the set
-of patches devices could fall back to later.
+Rolling back a superseded patch has no immediate effect, since devices are not
+served it. It removes that patch from the set devices can fall back to later.
 
 :::
 
 ### Why the Console may still show old patches installing
 
 Patch install events are reported the next time an app launches, which can be
-hours or days after the install happened. A patch that is no longer being served
-can therefore keep showing new install events for a while. This is a reporting
-delay, not devices downloading an old patch.
+hours or days later. A patch that is no longer served can keep showing new
+install events during that window.
 
 ## How to roll back a patch
 


### PR DESCRIPTION
## Status

**READY — semantics need a check before merge**

## Description

Fixes shorebirdtech/shorebird#2138.

"active" and "inactive" appear nowhere in the docs, but the Console uses them. The user in the issue concluded that each patch has its own on/off switch, that older patches must be turned off one at a time in order, and that they would then have to re-enable patch 1 by hand.

Adds an "Active and superseded patches" section to the rollback page, ahead of the rollback instructions.

### Where the rules come from

`selectLatestPatchInChannelQuery` in `code_push_database`, which is what answers a device's check-in. It filters `is_rolled_back = FALSE`, joins `app_channel_patch_history_` for the device's track, and takes `ORDER BY p.number DESC LIMIT 1`. From that:

- one patch is served per track at a time
- lower-numbered patches are superseded and need no deactivation
- rolling back the active patch drops devices to the next-highest non-rolled-back patch on the track, or the base release
- rolling back an already-superseded patch does not change what devices receive; it removes that patch from the set they can fall back to later

The last one is what I would like confirmed. It follows from the query, but I would rather someone who owns this code agree than have my reading become the documented contract.

### Also included

A subsection on why the Console can keep showing installs of a patch that is no longer served: install events are reported at next app launch. That was the second half of the confusion in the issue, and is what shorebirdtech/shorebird#2139 covers. If that issue changes the reporting, this should change with it.

### Verification

- `npx prettier --write` — clean
- `npx cspell --config .cspell.yaml` — 0 issues
- `npx astro build` — all internal links valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fnEF9Ch8k5VQnwmBGD1nn